### PR TITLE
Add lutro.window.close()

### DIFF
--- a/test/main.lua
+++ b/test/main.lua
@@ -4,7 +4,8 @@ local availableStates = {
 	"graphics/rectangle",
 	"graphics/line",
 	"math/random",
-	"audio/play"
+	"audio/play",
+	"window/close"
 }
 local states = {}
 local currentState = 1

--- a/test/window/close.lua
+++ b/test/window/close.lua
@@ -1,0 +1,5 @@
+return {
+	update = function()
+		lutro.window.close()
+	end
+}

--- a/window.c
+++ b/window.c
@@ -10,6 +10,7 @@ int lutro_window_preload(lua_State *L)
    static luaL_Reg win_funcs[] =  {
       { "setTitle", win_setTitle },
       { "setMode",  win_setMode },
+      { "close", lutro_window_close },
       {NULL, NULL}
    };
 
@@ -48,4 +49,10 @@ int win_setMode(lua_State *L)
    lua_pushboolean(L, true);
 
    return 1;
+}
+
+int lutro_window_close(lua_State *L)
+{
+   retro_unload_game();
+   return 0;
 }

--- a/window.h
+++ b/window.h
@@ -12,5 +12,6 @@ int lutro_window_preload(lua_State *L);
 
 int win_setTitle(lua_State *L);
 int win_setMode(lua_State *L);
+int lutro_window_close(lua_State *L);
 
 #endif // WINDOW_H


### PR DESCRIPTION
Not sure if `retro_unload_game()` is the right thing... Looks like there's no current implementation in the Lutro core.