### PR TITLE
Add polygon, circle and ellipse functions in lutro.graphics

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -16,7 +16,7 @@ SOURCES_C += $(CORE_DIR)/libretro.c \
 	$(CORE_DIR)/filesystem.c \
 	$(CORE_DIR)/system.c \
 	$(CORE_DIR)/timer.c \
-	$(CORE_DIR)/math.c \
+	$(CORE_DIR)/lutro_math.c \
 	$(CORE_DIR)/joystick.c \
 	$(CORE_DIR)/mouse.c \
 	$(CORE_DIR)/window.c \

--- a/graphics.c
+++ b/graphics.c
@@ -704,6 +704,79 @@ static int gfx_polygon(lua_State *L)
    return 0;
 }
 
+static int gfx_circle(lua_State *L)
+{
+   int n = lua_gettop(L);
+   gfx_Canvas *canvas;
+
+   if ((n != 4) && (n != 5))
+      return luaL_error(L, "lutro.graphics.circle requires 4 or 5 arguments, %d given.", n);
+
+   const char* mode = luaL_checkstring(L, 1);
+   int x = luaL_checknumber(L, 2);
+   int y = luaL_checknumber(L, 3);
+   int radius = luaL_checknumber(L, 4);
+   int nb_segments = 0;
+   if (n == 5)
+     nb_segments = luaL_checknumber(L, 5);
+   if (nb_segments <= 0)
+     nb_segments = max(10, radius);
+
+   canvas = get_canvas_ref(L, cur_canv);
+
+   if (!strcmp(mode, "fill"))
+   {
+      pntr_fill_ellipse(canvas, x, y, radius, radius, nb_segments);
+   }
+   else if (!strcmp(mode, "line"))
+   {
+      pntr_strike_ellipse(canvas, x, y, radius, radius, nb_segments);
+   }
+   else
+   {
+      return luaL_error(L, "lutro.graphics.circle's available modes are : fill or line", n);
+   }
+
+   return 0;
+}
+
+static int gfx_ellipse(lua_State *L)
+{
+   int n = lua_gettop(L);
+   gfx_Canvas *canvas;
+
+   if ((n != 5) && (n != 6))
+      return luaL_error(L, "lutro.graphics.ellipse requires 5 or 6 arguments, %d given.", n);
+
+   const char* mode = luaL_checkstring(L, 1);
+   int x = luaL_checknumber(L, 2);
+   int y = luaL_checknumber(L, 3);
+   int x_radius = luaL_checknumber(L, 4);
+   int y_radius = luaL_checknumber(L, 5);
+   int nb_segments = 0;
+   if (n == 6)
+     nb_segments = luaL_checknumber(L, 6);
+   if (nb_segments <= 0)
+     nb_segments = max(10, max(x_radius, y_radius));
+
+   canvas = get_canvas_ref(L, cur_canv);
+
+   if (!strcmp(mode, "fill"))
+   {
+      pntr_fill_ellipse(canvas, x, y, x_radius, y_radius, nb_segments);
+   }
+   else if (!strcmp(mode, "line"))
+   {
+      pntr_strike_ellipse(canvas, x, y, x_radius, y_radius, nb_segments);
+   }
+   else
+   {
+      return luaL_error(L, "lutro.graphics.circle's available modes are : fill or line", n);
+   }
+
+   return 0;
+}
+
 static int gfx_point(lua_State *L)
 {
    int n = lua_gettop(L);
@@ -1107,6 +1180,8 @@ int lutro_graphics_preload(lua_State *L)
 
       { "rectangle",    gfx_rectangle },
       { "polygon",      gfx_polygon },
+      { "circle",       gfx_circle },
+      { "ellipse",      gfx_ellipse },
       { "setBackgroundColor", gfx_setBackgroundColor },
       { "setColor",     gfx_setColor },
       { "setDefaultFilter", gfx_setDefaultFilter },

--- a/lutro.c
+++ b/lutro.c
@@ -14,7 +14,7 @@
 #include "filesystem.h"
 #include "system.h"
 #include "timer.h"
-#include "math.h"
+#include "lutro_math.h"
 #include "window.h"
 #include "live.h"
 #include "mouse.h"
@@ -51,13 +51,13 @@ lutro_settings_t settings = {
 static void dumpstack( lua_State* L )
 {
   int top = lua_gettop( L );
-  
+
   for ( int i = 1; i <= top; i++ )
   {
     printf( "%2d %3d ", i, i - top - 1 );
-    
+
     lua_pushvalue( L, i );
-    
+
     switch ( lua_type( L, -1 ) )
     {
     case LUA_TNIL:
@@ -92,7 +92,7 @@ static void dumpstack( lua_State* L )
       break;
     }
   }
-  
+
   lua_settop( L, top );
 }
 #endif
@@ -155,7 +155,7 @@ static int db_errorfb (lua_State *L) {
 static int dofile(lua_State *L, const char *path)
 {
    int res;
-   
+
    lua_pushcfunction(L, db_errorfb);
    res = luaL_loadfile(L, path);
 
@@ -527,14 +527,14 @@ void lutro_run(double delta)
 #endif
 
    lua_pushcfunction(L, db_errorfb);
-   
+
    lua_getglobal(L, "lutro");
    lua_getfield(L, -1, "update");
 
    if (lua_isfunction(L, -1))
    {
       lua_pushnumber(L, delta);
-      
+
       if(lua_pcall(L, 1, 0, -4))
       {
          fprintf(stderr, "%s\n", lua_tostring(L, -1));
@@ -545,11 +545,11 @@ void lutro_run(double delta)
    }
 
    lua_getfield(L, -1, "draw");
-   
+
    if (lua_isfunction(L, -1))
    {
       lutro_graphics_begin_frame(L);
-      
+
       if(lua_pcall(L, 0, 0, -3))
       {
          fprintf(stderr, "%s\n", lua_tostring(L, -1));

--- a/lutro_math.c
+++ b/lutro_math.c
@@ -1,6 +1,6 @@
 
 #include "lutro.h"
-#include "math.h"
+#include "lutro_math.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/lutro_math.h
+++ b/lutro_math.h
@@ -1,5 +1,5 @@
-#ifndef MATH_H
-#define MATH_H
+#ifndef LUTRO_MATH_H
+#define LUTRO_MATH_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -12,4 +12,4 @@ int lutro_math_preload(lua_State *L);
 int lutro_math_random(lua_State *L);
 int lutro_math_setRandomSeed(lua_State *L);
 
-#endif // MATH_H
+#endif // LUTRO_MATH_H

--- a/painter.c
+++ b/painter.c
@@ -10,6 +10,9 @@
 #include <assert.h>
 #include <retro_miscellaneous.h>
 
+#include <math.h>
+#define M_PI 3.14159265358979323846
+
 #ifndef max
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #endif
@@ -191,6 +194,22 @@ void pntr_fill_poly(painter_t *p, const int *points, int nb_points)
    // TODO
 }
 
+void pntr_strike_ellipse(painter_t *p, int x, int y, int radius_x, int radius_y, int nb_segments)
+{
+   for (int i = 0; i < nb_segments; ++i)
+   {
+      int x1 = x + (radius_x * cos(2 * i * M_PI / nb_segments));
+      int y1 = y + (radius_y * sin(2 * i * M_PI / nb_segments));
+      int x2 = x + (radius_x * cos(2 * (i + 1) * M_PI / nb_segments));
+      int y2 = y + (radius_y * sin(2 * (i + 1) * M_PI / nb_segments));
+      pntr_strike_line(p, x1, y1, x2, y2);
+   }
+}
+
+void pntr_fill_ellipse(painter_t *p, int x, int y, int radius_x, int radius_y, int nb_segments)
+{
+   // TODO
+}
 
 void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const rect_t *dst_rect)
 {

--- a/painter.h
+++ b/painter.h
@@ -72,6 +72,8 @@ void pntr_strike_rect(painter_t *p, const rect_t *rect);
 void pntr_fill_rect(painter_t *p, const rect_t *rect);
 void pntr_strike_poly(painter_t *p, const int *points, int nb_points);
 void pntr_fill_poly(painter_t *p, const int *points, int nb_points);
+void pntr_strike_ellipse(painter_t *p, int x, int y, int radius_x, int radius_y, int nb_segments);
+void pntr_fill_ellipse(painter_t *p, int x, int y, int radius_x, int radius_y, int nb_segments);
 void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const rect_t *dst_rect);
 void pntr_print(painter_t *p, int x, int y, const char *text);
 int  pntr_text_width(painter_t *p, const char *text);

--- a/painter.h
+++ b/painter.h
@@ -67,8 +67,11 @@ struct painter_s
 void pntr_reset(painter_t *p);
 void pntr_clear(painter_t *p);
 void pntr_sanitize_clip(painter_t *p);
+void pntr_strike_line(painter_t *p, int x1, int y1, int x2, int y2);
 void pntr_strike_rect(painter_t *p, const rect_t *rect);
 void pntr_fill_rect(painter_t *p, const rect_t *rect);
+void pntr_strike_poly(painter_t *p, const int *points, int nb_points);
+void pntr_fill_poly(painter_t *p, const int *points, int nb_points);
 void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const rect_t *dst_rect);
 void pntr_print(painter_t *p, int x, int y, const char *text);
 int  pntr_text_width(painter_t *p, const char *text);


### PR DESCRIPTION
This pull request adds the following functions in lutro.graphics:
- polygon
- circle
- ellipse

The fill and line modes are both implemented. The line mode is also implemented for the rectangle function (instead of being commented out).

The polygon function have the following restrictions:
- the two arguments variant (where the second argument is a table of points) is not implemented.
- the fill mode is correct for convex polygons only. This is not a big issue since LÖVE has the same problem.

The polygon function also does a dynamic memory allocation to store the list of points. Since the number of points is not restricted, a static array does work for every cases. If this is a problem, I could modify the code to use a static array when the number of points is low (less that 10 points for instance).

In order to be able to include the <math.h> standard include file in painter.c (to draw ellipses and circle), I had to rename the math.h file (and math.c) into lutro_math.h (and lutro_math.c). If those are not renamed, the compiler complains about the cos and sin functions being defined implicitely (and M_PI undefined).