### PR TITLE
Add Docker support to allow Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - make docker
+
+notifications:
+  email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+MAINTAINER libretro
+
+# Update all dependencies
+RUN apt-get update && apt-get upgrade -y
+
+# Install RetroArch's build dependencies
+RUN apt-get install -y make git-core curl g++ pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev
+
+VOLUME ["/app"]
+WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -267,4 +267,8 @@ clean:
 	-make -C $(LUADIR) clean
 	-rm -f $(OBJS) $(TARGET)
 
+docker:
+	docker build -t libretro-lutro .
+	docker run -v $(CURDIR):/app libretro-lutro make
+
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ Through RetroArch, use the Lutro core to load the game's source directory:
 Alternatively, you can load a compressed `.lutro` file:
 
     retroarch -L libretro_lutro.so game.lutro
+
+## Build
+
+Compile Lutro by [installing the RetroArch dependencies](https://github.com/libretro/retroarch#dependencies-pc), and running:
+
+    make
+
+To compile with [Docker](https://www.docker.com/), use:
+
+    make docker


### PR DESCRIPTION
Adding [Docker](https://www.docker.com/) build support means we could build `libretro_lutro.so` on Travis for some automated testing goodness.

    make docker

Will build the container, and then run `make` through it.