### PR TITLE
Fix build when ARCH=x86_64 is specified.

### DIFF
--- a/deps/lua/src/Makefile
+++ b/deps/lua/src/Makefile
@@ -8,7 +8,7 @@
 PLAT= none
 
 CC= gcc
-CFLAGS= -O2 -Wall $(MYCFLAGS)
+CFLAGS= -O2 -Wall -fPIC $(MYCFLAGS)
 AR= ar rcu
 RANLIB= ranlib
 RM= rm -f


### PR DESCRIPTION
If `ARCH=x86_64` is specified in the build environment when running make lua will fail to build as -fPIC is not used in the lua Makefile.

This will fix issue https://github.com/libretro/libretro-lutro/issues/93.