### PR TITLE
Allow Docker to run Lutro tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,21 @@ FROM ubuntu:16.04
 MAINTAINER libretro
 
 # Update all dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y
 
 # Install RetroArch's build dependencies
-RUN apt-get install -y make git-core curl g++ pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev
+RUN apt-get install -y make git-core curl g++ pkg-config libglu1-mesa-dev freeglut3-dev mesa-common-dev libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev software-properties-common
+
+# Install RetroArch from the PPA
+RUN apt-add-repository -y multiverse
+RUN add-apt-repository -y ppa:libretro/testing
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install retroarch -y
+RUN mkdir -p ~/.config/retroarch
+RUN echo "video_driver = \"null\"" >> ~/.config/retroarch/retroarch.cfg
+RUN echo "audio_driver = \"null\"" >> ~/.config/retroarch/retroarch.cfg
+RUN echo "confirm_on_exit = \"false\"" >> ~/.config/retroarch/retroarch.cfg
 
 VOLUME ["/app"]
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -268,9 +268,25 @@ clean:
 	-make -C $(LUADIR) clean
 	-rm -f $(OBJS) $(TARGET)
 
-docker:
-	docker build -t libretro-lutro .
-	docker run -v $(CURDIR):/app libretro-lutro make
+docker-build:
+	@docker build -t libretro-lutro .
+
+docker: docker-build
+	@docker run -it \
+		-v $(CURDIR):/app \
+		libretro-lutro \
+			make
+
+docker-test: docker
+	@docker run -it \
+		-v $(CURDIR):/app \
+		--name retroarch \
+		libretro-lutro \
+			retroarch -L lutro_libretro.so test/unit
+
+docker-kill:
+	@-docker kill retroarch
+	@-docker rm -f retroarch
 
 test: all
 	retroarch -L lutro_libretro.so test


### PR DESCRIPTION
:warning: :x: :warning: Don't merge this yet....

The goal here is to allow running the Lutro unit tests through [Docker](https://www.docker.com/). This will allow Travis to run the lua tests.

### Usage

```
make docker-test
```

### Status

It runs the unit tests, and outputs "Lutro unit test run complete", but RetroArch does not close after running, even though Lutro calls `RETRO_ENVIRONMENT_SHUTDOWN`.