### PR TITLE
Init physfs.

### DIFF
--- a/lutro.c
+++ b/lutro.c
@@ -269,6 +269,8 @@ void lutro_init()
    lutro_require(L, "lutro.live", 1);
 #endif
 
+   lutro_filesystem_init();
+
    lutro_checked_stack_assert(0);
 }
 


### PR DESCRIPTION
Fixes as segfault when closing content.
```
Thread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x00007fffed89e7fd in PHYSFS_setErrorCode (errcode=PHYSFS_ERR_NOT_INITIALIZED) at deps/physfs/physfs.c:763
#2  0x00007fffed89fbe6 in PHYSFS_deinit () at deps/physfs/physfs.c:1393
#3  0x00007fffed87f5b1 in lutro_filesystem_deinit () at filesystem.c:50
#4  0x00007fffed878e06 in lutro_deinit () at lutro.c:283
#5  0x00007fffed8783c7 in retro_unload_game () at libretro.c:220
#6  0x000000000041ad12 in core_unload_game () at core_impl.c:409
#7  0x000000000042b2f2 in command_event_deinit_core (reinit=true) at command.c:1085
#8  0x000000000042f242 in command_event (cmd=CMD_EVENT_CORE_DEINIT, data=0x0) at command.c:2291
#9  0x000000000041ef1f in rarch_ctl (state=RARCH_CTL_MAIN_DEINIT, data=0x0) at retroarch.c:1594
#10 0x0000000000417bb6 in main_exit (args=0x0) at frontend/frontend.c:70
#11 0x0000000000417f31 in rarch_main (argc=4, argv=0x7fffffffe198, data=0x0) at frontend/frontend.c:152
#12 0x0000000000417fd4 in main (argc=4, argv=0x7fffffffe198) at frontend/frontend.c:169
```