### PR TITLE
 Update to physfs 3.0.1.

### DIFF
--- a/deps/physfs/README.txt
+++ b/deps/physfs/README.txt
@@ -1,0 +1,9 @@
+
+PhysicsFS; a portable, flexible file i/o abstraction.
+
+  https://icculus.org/physfs/
+
+Please see the docs directory for documentation.
+
+Please see LICENSE.txt for licensing information.
+

--- a/deps/physfs/physfs_archiver_dir.c
+++ b/deps/physfs/physfs_archiver_dir.c
@@ -49,7 +49,8 @@ static void *DIR_openArchive(PHYSFS_Io *io, const char *name,
     const size_t seplen = 1;
 
     assert(io == NULL);  /* shouldn't create an Io for these. */
-    BAIL_IF_ERRPASS(!__PHYSFS_platformStat(name, &st), NULL);
+    BAIL_IF_ERRPASS(!__PHYSFS_platformStat(name, &st, 1), NULL);
+
     if (st.filetype != PHYSFS_FILETYPE_DIRECTORY)
         BAIL(PHYSFS_ERR_UNSUPPORTED, NULL);
 
@@ -97,7 +98,7 @@ static PHYSFS_Io *doOpen(void *opaque, const char *name, const int mode)
     {
         const PHYSFS_ErrorCode err = PHYSFS_getLastErrorCode();
         PHYSFS_Stat statbuf;
-        __PHYSFS_platformStat(f, &statbuf);
+        __PHYSFS_platformStat(f, &statbuf, 0);  /* !!! FIXME: why are we stating here? */
         PHYSFS_setErrorCode(err);
     } /* if */
 
@@ -164,7 +165,7 @@ static int DIR_stat(void *opaque, const char *name, PHYSFS_Stat *stat)
 
     CVT_TO_DEPENDENT(d, opaque, name);
     BAIL_IF_ERRPASS(!d, 0);
-    retval = __PHYSFS_platformStat(d, stat);
+    retval = __PHYSFS_platformStat(d, stat, 0);
     __PHYSFS_smallFree(d);
     return retval;
 } /* DIR_stat */

--- a/deps/physfs/physfs_archiver_zip.c
+++ b/deps/physfs/physfs_archiver_zip.c
@@ -455,6 +455,7 @@ static PHYSFS_Io *ZIP_duplicate(PHYSFS_Io *io)
     finfo->io = zip_get_io(origfinfo->io, NULL, finfo->entry);
     GOTO_IF_ERRPASS(!finfo->io, failed);
 
+    initializeZStream(&finfo->stream);
     if (finfo->entry->compression_method != COMPMETH_NONE)
     {
         finfo->buffer = (PHYSFS_uint8 *) allocator.Malloc(ZIP_READBUFSIZE);

--- a/deps/physfs/physfs_internal.h
+++ b/deps/physfs/physfs_internal.h
@@ -549,11 +549,12 @@ PHYSFS_sint64 __PHYSFS_platformFileLength(void *handle);
  *
  * This needs to fill in all the fields of (stat). For fields that might not
  *  mean anything on a platform (access time, perhaps), choose a reasonable
- *  default.
+ *  default. if (follow), we want to follow symlinks and stat what they
+ *  link to and not the link itself.
  *
  *  Return zero on failure, non-zero on success.
  */
-int __PHYSFS_platformStat(const char *fn, PHYSFS_Stat *stat);
+int __PHYSFS_platformStat(const char *fn, PHYSFS_Stat *stat, const int follow);
 
 /*
  * Flush any pending writes to disk. (opaque) should be cast to whatever data

--- a/deps/physfs/physfs_platform_posix.c
+++ b/deps/physfs/physfs_platform_posix.c
@@ -296,11 +296,11 @@ int __PHYSFS_platformDelete(const char *path)
 } /* __PHYSFS_platformDelete */
 
 
-int __PHYSFS_platformStat(const char *filename, PHYSFS_Stat *st)
+int __PHYSFS_platformStat(const char *fname, PHYSFS_Stat *st, const int follow)
 {
     struct stat statbuf;
-
-    BAIL_IF(lstat(filename, &statbuf) == -1, errcodeFromErrno(), 0);
+    const int rc = follow ? stat(fname, &statbuf) : lstat(fname, &statbuf);
+    BAIL_IF(rc == -1, errcodeFromErrno(), 0);
 
     if (S_ISREG(statbuf.st_mode))
     {
@@ -330,7 +330,7 @@ int __PHYSFS_platformStat(const char *filename, PHYSFS_Stat *st)
     st->createtime = statbuf.st_ctime;
     st->accesstime = statbuf.st_atime;
 
-    st->readonly = (access(filename, W_OK) == -1);
+    st->readonly = (access(fname, W_OK) == -1);
     return 1;
 } /* __PHYSFS_platformStat */
 

--- a/deps/physfs/physfs_platform_windows.c
+++ b/deps/physfs/physfs_platform_windows.c
@@ -960,7 +960,7 @@ static int isSymlink(const WCHAR *wpath, const DWORD attr)
 } /* isSymlink */
 
 
-int __PHYSFS_platformStat(const char *filename, PHYSFS_Stat *st)
+int __PHYSFS_platformStat(const char *filename, PHYSFS_Stat *st, const int follow)
 {
     WIN32_FILE_ATTRIBUTE_DATA winstat;
     WCHAR *wstr = NULL;
@@ -975,7 +975,7 @@ int __PHYSFS_platformStat(const char *filename, PHYSFS_Stat *st)
     if (!rc)
         err = GetLastError();
     else  /* check for symlink while wstr is still available */
-        issymlink = isSymlink(wstr, winstat.dwFileAttributes);
+        issymlink = !follow && isSymlink(wstr, winstat.dwFileAttributes);
 
     __PHYSFS_smallFree(wstr);
     BAIL_IF(!rc, errcodeFromWinApiError(err), 0);


### PR DESCRIPTION
Updates physfs from 2.2.1 to 3.0.1.

source: https://icculus.org/physfs/downloads/physfs-3.0.1.tar.bz2
md5sum: 359f102bcbd62accf84ef32f4863255d

This updates physfs to the latest stable release. I tested this against all the lutro content in the online updater without finding regressions, but please review this. :)