### PR TITLE
Fix segfault when loaded without content.

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -67,8 +67,6 @@ void retro_init(void)
 
 void retro_deinit(void)
 {
-   lutro_deinit();
-
    if (settings.framebuffer) {
       free(settings.framebuffer);
       settings.framebuffer = NULL;
@@ -219,6 +217,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
 void retro_unload_game(void)
 {
+   lutro_deinit();
 }
 
 void lutro_shutdown_game(void)


### PR DESCRIPTION
My understanding is this is a combination of a frontend bug in RetroArch and a core bug in lutro. RetroArch attempts to unload content even when it was never loaded and lutro is deiniting content in retro_deinit instead of retro_unload_core.

Please see:

https://github.com/libretro/RetroArch/issues/4493
https://github.com/libretro/RetroArch/pull/7102

Note that this fix in lutro is enough without also requiring the fix in RetroArch which is needed for other cores.