### PR TITLE
utf-8: input to tolower must always be unsigned

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -183,7 +183,7 @@ int audio_newSource(lua_State *L)
       char ext[PATH_MAX_LENGTH];
       strcpy(ext, path_get_extension(path));
       for(int i = 0; ext[i]; i++)
-         ext[i] = tolower(ext[i]);
+         ext[i] = tolower((uint8_t)ext[i]);
       
       //ogg
       if (strstr(ext, "ogg"))


### PR DESCRIPTION
This is an easy and often-made mistake. The input to tolower() is signed, but UTF-8 uses a trick of unsigned ASCII to work its magic. The MSB (most-significant bit) of UTF8 chars becomes a negative number when passed into tolower() and it errors out.

Thus, in our new everything-is-UTF8 world, we must ALWAYS typecast from `char` to `unsigned char` or `uint8_t`

_(note that libretro and ogg vorbis **have this same error still too** -- I will submit PRs for them as well, later... )_