### PR TITLE
audio: perform correct unit-sizing and saturation of mixed audio for all srcs

### DIFF
--- a/audio.h
+++ b/audio.h
@@ -11,6 +11,24 @@
 
 #define AUDIO_FRAMES (44100 / 60)
 
+// The following types are acceptable for pre-saturated mixing, as they meet the requirement for
+// having a larger range than the saturated mixer result type of int16_t. double precision should
+// be preferred on x86/amd64, and single precision on ARM. float16 could also work as an input
+// but care must be taken to saturate at INT16_MAX-1 and INT16_MIN+1 due to float16 not having a
+// 1:1 representation of whole numbers in the in16 range.
+//
+// TODO: set up appropriate compiler defs for mixer presaturate type.
+
+typedef float   mixer_presaturate_t;
+#define cvt_presaturate_to_int16(in)   ((int16_t)roundf(in))
+
+//typedef double  mixer_presaturate_t;
+//#define cvt_presaturate_to_int16(in)   (round(in))
+
+//typedef int32_t mixer_presaturate_t;
+//#define cvt_presaturate_to_int16(in)   ((int16_t)in)
+
+
 typedef enum
 {
    AUDIO_STOPPED = 0,

--- a/decoder.c
+++ b/decoder.c
@@ -6,7 +6,6 @@
 #include "audio.h"
 
 #define CHANNELS 2
-float floatData[AUDIO_FRAMES * CHANNELS];
 
 //
 bool decoder_initOgg(OggData *data, char *filename)
@@ -66,8 +65,9 @@ bool decoder_sampleTell(OggData *data, uint32_t *pos)
 	return false;
 }
 
-//
-bool decoder_decodeOgg(OggData *data, float *buffer, float volume, bool loop)
+// decoded data is mixed (added) into the presaturated mixer buffer.
+// the buffer must be manually cleared to zero for non-mixing (raw) use cases.
+bool decoder_decodeOgg(OggData *data, mixer_presaturate_t *buffer, float volume, bool loop)
 {
 	//printf("decoder_decodeOgg\n");
 
@@ -75,7 +75,7 @@ bool decoder_decodeOgg(OggData *data, float *buffer, float volume, bool loop)
 	size_t rendered = 0;
 	bool finished = false;
 
-	float *dst = floatData;
+	float *dst = buffer;
 
 	while (frames)
 	{
@@ -109,16 +109,16 @@ bool decoder_decodeOgg(OggData *data, float *buffer, float volume, bool loop)
 		{
 			for (long i = 0; i < ret; i++)
 			{
-				dst[i * CHANNELS + 0] = pcm[0][i];
-				dst[i * CHANNELS + 1] = pcm[1][i];
+				dst[i * CHANNELS + 0] += pcm[0][i] * volume;
+				dst[i * CHANNELS + 1] += pcm[1][i] * volume;
 			}
 		}
 		else
 		{
 			for (long i = 0; i < ret; i++)
 			{
-				dst[i * CHANNELS + 0] = pcm[0][i];
-				dst[i * CHANNELS + 1] = pcm[0][i];
+				dst[i * CHANNELS + 0] += pcm[0][i];
+				dst[i * CHANNELS + 1] += pcm[0][i];
 			}
 		}
 
@@ -127,6 +127,5 @@ bool decoder_decodeOgg(OggData *data, float *buffer, float volume, bool loop)
 		rendered += ret;
 	}
 	
-	audio_mix_volume(buffer, floatData, volume, rendered * CHANNELS);
 	return finished;
 }


### PR DESCRIPTION
 - Fixes audio static when mixing ogg vorbis source audio
 - reduces memory usage
 - simplifies mixing logics
 - documents a specific issue with our 8-bit sample mixing which I'll aim to fix via a separate PR

It also includes my .editorconfig, so please merge first PR #169 and that'll get cleaned out from the diff :)