### PR TITLE
audio: temporary workaround for audio crashing

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -39,6 +39,7 @@ int audio_sources_nullify_refs(const snd_SoundData* sndta)
          if (sources[i]->state != AUDIO_STOPPED)
             ++counted;
    
+         // do not free - the pointers in sources are lua user data
          sources[i] = NULL;
       }
    }

--- a/audio.c
+++ b/audio.c
@@ -24,17 +24,17 @@ static int16_t saturate(mixer_presaturate_t in) {
    return cvt_presaturate_to_int16(in);
 }
 
-int audio_sources_nullify_refs(const snd_SoundData* sndta)
+int audio_sources_nullify_refs(const audio_Source* source)
 {
    int counted = 0;
-   if (!sndta->fp) return 0;
+   if (!source) return 0;
 
    // rather than crash, let's nullify any known references here,
    // even if they're currently playing (they'll be cut to silence)
 
    for(int i=0; i<num_sources; ++i)
    {
-      if (sources[i] && sources[i]->sndta.fp == sndta->fp)
+      if (sources[i] == source)
       {
          if (sources[i]->state != AUDIO_STOPPED)
             ++counted;

--- a/audio.h
+++ b/audio.h
@@ -63,6 +63,8 @@ int audio_getVolume(lua_State *L);
 int audio_play(lua_State *L);
 int audio_stop(lua_State *L);
 
+int audio_sources_nullify_refs(const snd_SoundData* sndta);
+
 int source_setLooping(lua_State *L);
 int source_isLooping(lua_State *L);
 int source_isStopped(lua_State *L);
@@ -76,5 +78,6 @@ int source_getPitch(lua_State *L);
 int source_setPitch(lua_State *L);
 
 int source_gc(lua_State *L);
+
 
 #endif // AUDIO_H

--- a/audio.h
+++ b/audio.h
@@ -63,8 +63,6 @@ int audio_getVolume(lua_State *L);
 int audio_play(lua_State *L);
 int audio_stop(lua_State *L);
 
-int audio_sources_nullify_refs(const snd_SoundData* sndta);
-
 int source_setLooping(lua_State *L);
 int source_isLooping(lua_State *L);
 int source_isStopped(lua_State *L);

--- a/sound.c
+++ b/sound.c
@@ -1,5 +1,6 @@
 #include "sound.h"
 #include "lutro.h"
+#include "audio.h"
 #include "compat/strl.h"
 
 #include <stdlib.h>

--- a/sound.c
+++ b/sound.c
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 int lutro_sound_preload(lua_State *L)
 {
@@ -23,6 +24,11 @@ int lutro_sound_preload(lua_State *L)
 
 void lutro_sound_init()
 {
+}
+
+void newSoundData_internal(lua_State *L, const char* path)
+{
+   snd_SoundData* self = (snd_SoundData*)lua_newuserdata(L, sizeof(snd_SoundData));
 }
 
 int snd_newSoundData(lua_State *L)
@@ -72,7 +78,7 @@ int snd_newSoundData(lua_State *L)
 
 int sndta_type(lua_State *L)
 {
-   wavhead_t* self = (wavhead_t*)luaL_checkudata(L, 1, "SoundData");
+   snd_SoundData* self = (snd_SoundData*)luaL_checkudata(L, 1, "SoundData");
    (void) self;
    lua_pushstring(L, "SoundData");
    return 1;
@@ -80,7 +86,20 @@ int sndta_type(lua_State *L)
 
 int sndta_gc(lua_State *L)
 {
-   wavhead_t* self = (wavhead_t*)luaL_checkudata(L, 1, "SoundData");
+   snd_SoundData* self = (snd_SoundData*)luaL_checkudata(L, 1, "SoundData");
+   if (!self) return 0;
+
+   // todo - add some info to help identify the offending leaker.
+   // (don't get carried away tho - this message is only really useful to lutro core devs since
+   //  it indiciates a failure of our internal Lua/C glue)
+
+   int leaks = audio_sources_nullify_refs(self);
+   if (leaks)
+   {
+      fprintf(stderr, "sndta_gc: playing audio references were nullified.\n");
+      //assert(false);
+   }
+
    (void)self;
    return 0;
 }

--- a/sound.c
+++ b/sound.c
@@ -88,18 +88,8 @@ int sndta_type(lua_State *L)
 int sndta_gc(lua_State *L)
 {
    snd_SoundData* self = (snd_SoundData*)luaL_checkudata(L, 1, "SoundData");
-   if (!self) return 0;
 
-   // todo - add some info to help identify the offending leaker.
-   // (don't get carried away tho - this message is only really useful to lutro core devs since
-   //  it indiciates a failure of our internal Lua/C glue)
-
-   int leaks = audio_sources_nullify_refs(self);
-   if (leaks)
-   {
-      fprintf(stderr, "sndta_gc: playing audio references were nullified.\n");
-      //assert(false);
-   }
+   //audio makes deep copies of this object when it preps it as a mixer source, so no cleanup needed here.
 
    (void)self;
    return 0;


### PR DESCRIPTION
Works around crash in Issue #163 (but does not fix it yet)

This change nullifies samples on unexpected __gc. This is a decent fallback to have in case __gc ever fails. Cutting samples is better than crashing.

This fix does not play nice with SLAM! since that library depends on local refs and implicit __gc of handles while audio continues to under-the-hood. I will look to get a proper SLAM-friendly fix written up during the week.