### PR TITLE
microsoft visual studio projects added, adds 'make vcxproj' to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Editor workspaces
+.vs/
+.vscode/
+*.user
+
 # Object files
 *.o
 *.ko
@@ -5,9 +10,10 @@
 *.elf
 /obj
 
-# Precompiled Headers
+# Precompiled Headers vand other Build Artifacts
 *.gch
 *.pch
+*.ilk
 
 # Libraries
 *.lib
@@ -23,6 +29,7 @@
 
 # Executables
 *.exe
+*.pdb
 *.out
 *.app
 *.i*86

--- a/Makefile.common
+++ b/Makefile.common
@@ -5,9 +5,7 @@ INCFLAGS := -I$(CORE_DIR) \
 				-I$(CORE_DIR)/deps/zlib \
 				-I$(CORE_DIR)/deps/vorbis \
 				-I$(CORE_DIR)/deps/ogg \
-				-I$(CORE_DIR)/deps \
-				-I$(LUALIB_DIR)
-
+				-I$(CORE_DIR)/deps
 
 SOURCES_C := $(CORE_DIR)/libretro.c \
                  $(CORE_DIR)/lutro.c \
@@ -30,6 +28,7 @@ SOURCES_C := $(CORE_DIR)/libretro.c \
                  $(CORE_DIR)/painter.c
 
 ifeq ($(WANT_LUALIB),1)
+INCFLAGS += -I$(LUALIB_DIR)
 SOURCES_C += $(LUALIB_DIR)/lapi.c \
                  $(LUALIB_DIR)/lauxlib.c \
                  $(LUALIB_DIR)/lbaselib.c \
@@ -180,7 +179,11 @@ ifeq ($(WANT_PHYSFS), 1)
 endif
 
 # Ogg Vorbis
-SOURCES_C += \
+# These sources are added to their own list so that they can be handled differently when generating
+# windows msbuild scripts. Notably, msbuild doesn't like window.c because it conflicts with window.c
+# in lutro -- such things can only be resolved in msbuld by using project encapsulation.
+
+VORBIS_SOURCES_C += \
 	$(CORE_DIR)/deps/ogg/bitwise.c \
 	$(CORE_DIR)/deps/ogg/framing.c \
 	$(CORE_DIR)/deps/vorbis/analysis.c \

--- a/libretro.c
+++ b/libretro.c
@@ -298,7 +298,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
    (void)code;
 }
 
-#ifdef __QNX__
+#if defined(__QNX__) || defined(_MSC_VER)
 /* QNX doesn't have this */
 int vasprintf(char **strp, const char *fmt, va_list ap)
 {

--- a/live.c
+++ b/live.c
@@ -1,6 +1,7 @@
 #include "live.h"
 #include "lutro.h"
 
+#ifdef HAVE_INOTIFY
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -318,3 +319,4 @@ void lutro_live_draw()
 {
 
 }
+#endif

--- a/lutro.c
+++ b/lutro.c
@@ -38,10 +38,13 @@
 #include <string.h>
 
 #include <assert.h>
+
+#if !defined(_MSC_VER)
 #ifndef __CELLOS_LV2__
 #include <libgen.h>
 #endif
 #include <unistd.h>
+#endif
 
 static lua_State *L;
 static int16_t input_cache[16];

--- a/lutro.sln
+++ b/lutro.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lutro", "msbuild\lutro.vcxproj", "{18CEB57F-9D09-4FAB-AEEE-08B094055423}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lua", "msbuild\lua.vcxproj", "{A5743DF4-3D23-4D9F-A01E-6903F364601B}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vorbis", "msbuild\vorbis.vcxproj", "{B4A07901-6615-4460-B907-5F0A2838AC34}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{18CEB57F-9D09-4FAB-AEEE-08B094055423}.Debug|x64.ActiveCfg = Debug|x64
+		{18CEB57F-9D09-4FAB-AEEE-08B094055423}.Debug|x64.Build.0 = Debug|x64
+		{18CEB57F-9D09-4FAB-AEEE-08B094055423}.Release|x64.ActiveCfg = Release|x64
+		{18CEB57F-9D09-4FAB-AEEE-08B094055423}.Release|x64.Build.0 = Release|x64
+		{A5743DF4-3D23-4D9F-A01E-6903F364601B}.Debug|x64.ActiveCfg = Debug|x64
+		{A5743DF4-3D23-4D9F-A01E-6903F364601B}.Debug|x64.Build.0 = Debug|x64
+		{A5743DF4-3D23-4D9F-A01E-6903F364601B}.Release|x64.ActiveCfg = Release|x64
+		{A5743DF4-3D23-4D9F-A01E-6903F364601B}.Release|x64.Build.0 = Release|x64
+		{B4A07901-6615-4460-B907-5F0A2838AC34}.Debug|x64.ActiveCfg = Debug|x64
+		{B4A07901-6615-4460-B907-5F0A2838AC34}.Debug|x64.Build.0 = Debug|x64
+		{B4A07901-6615-4460-B907-5F0A2838AC34}.Release|x64.ActiveCfg = Release|x64
+		{B4A07901-6615-4460-B907-5F0A2838AC34}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4D394883-F6D5-41DA-B6EB-28EC75319A43}
+	EndGlobalSection
+EndGlobal

--- a/msbuild/.gitignore
+++ b/msbuild/.gitignore
@@ -1,0 +1,3 @@
+*_sources.props
+lib/
+obj/

--- a/msbuild/lua.vcxproj
+++ b/msbuild/lua.vcxproj
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\deps\lua\src\lapi.c" />
+    <ClCompile Include="..\deps\lua\src\lauxlib.c" />
+    <ClCompile Include="..\deps\lua\src\lbaselib.c" />
+    <ClCompile Include="..\deps\lua\src\lcode.c" />
+    <ClCompile Include="..\deps\lua\src\ldblib.c" />
+    <ClCompile Include="..\deps\lua\src\ldebug.c" />
+    <ClCompile Include="..\deps\lua\src\ldo.c" />
+    <ClCompile Include="..\deps\lua\src\ldump.c" />
+    <ClCompile Include="..\deps\lua\src\lfunc.c" />
+    <ClCompile Include="..\deps\lua\src\lgc.c" />
+    <ClCompile Include="..\deps\lua\src\linit.c" />
+    <ClCompile Include="..\deps\lua\src\liolib.c" />
+    <ClCompile Include="..\deps\lua\src\llex.c" />
+    <ClCompile Include="..\deps\lua\src\lmathlib.c" />
+    <ClCompile Include="..\deps\lua\src\lmem.c" />
+    <ClCompile Include="..\deps\lua\src\loadlib.c" />
+    <ClCompile Include="..\deps\lua\src\lobject.c" />
+    <ClCompile Include="..\deps\lua\src\lopcodes.c" />
+    <ClCompile Include="..\deps\lua\src\loslib.c" />
+    <ClCompile Include="..\deps\lua\src\lparser.c" />
+    <ClCompile Include="..\deps\lua\src\lstate.c" />
+    <ClCompile Include="..\deps\lua\src\lstring.c" />
+    <ClCompile Include="..\deps\lua\src\lstrlib.c" />
+    <ClCompile Include="..\deps\lua\src\ltable.c" />
+    <ClCompile Include="..\deps\lua\src\ltablib.c" />
+    <ClCompile Include="..\deps\lua\src\ltm.c" />
+    <ClCompile Include="..\deps\lua\src\lundump.c" />
+    <ClCompile Include="..\deps\lua\src\lvm.c" />
+    <ClCompile Include="..\deps\lua\src\lzio.c" />
+    <ClCompile Include="..\deps\lua\src\print.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{A5743DF4-3D23-4D9F-A01E-6903F364601B}</ProjectGuid>
+    <RootNamespace>lua</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Multibyte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Multibyte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)/msbuild/lib/$(Platform)_$(Configuration)/</OutDir>
+    <IntDir>$(SolutionDir)/msbuild/obj/$(Platform)_$(Configuration)/$(ProjectName)/</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="lutro_build.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msbuild/lutro.vcxproj
+++ b/msbuild/lutro.vcxproj
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="lua.vcxproj">
+      <Project>{a5743df4-3d23-4d9f-a01e-6903f364601b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="vorbis.vcxproj">
+      <Project>{b4a07901-6615-4460-b907-5f0a2838ac34}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <!-- TODO : we could add a target that performs error checking and print a friendly message to the user -->
+  <Import Project="lutro_sources.props" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{18ceb57f-9d09-4fab-aeee-08b094055423}</ProjectGuid>
+    <RootNamespace>sdlarch</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>lutro_libretro</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Multibyte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Multibyte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)</OutDir>
+    <IntDir>$(SolutionDir)/obj/$(Platform)_$(Configuration)/$(ProjectName)/</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="lutro_build.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msbuild/lutro_build.props
+++ b/msbuild/lutro_build.props
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+   <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/msbuild/vorbis.vcxproj
+++ b/msbuild/vorbis.vcxproj
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="../deps/ogg/bitwise.c" />
+    <ClCompile Include="../deps/ogg/framing.c" />
+    <ClCompile Include="../deps/vorbis/analysis.c" />
+    <ClCompile Include="../deps/vorbis/barkmel.c" />
+    <ClCompile Include="../deps/vorbis/bitrate.c" />
+    <ClCompile Include="../deps/vorbis/block.c" />
+    <ClCompile Include="../deps/vorbis/codebook.c" />
+    <ClCompile Include="../deps/vorbis/envelope.c" />
+    <ClCompile Include="../deps/vorbis/floor0.c" />
+    <ClCompile Include="../deps/vorbis/floor1.c" />
+    <ClCompile Include="../deps/vorbis/info.c" />
+    <ClCompile Include="../deps/vorbis/lookup.c" />
+    <ClCompile Include="../deps/vorbis/lpc.c" />
+    <ClCompile Include="../deps/vorbis/lsp.c" />
+    <ClCompile Include="../deps/vorbis/mapping0.c" />
+    <ClCompile Include="../deps/vorbis/mdct.c" />
+    <ClCompile Include="../deps/vorbis/psy.c" />
+    <ClCompile Include="../deps/vorbis/registry.c" />
+    <ClCompile Include="../deps/vorbis/res0.c" />
+    <ClCompile Include="../deps/vorbis/sharedbook.c" />
+    <ClCompile Include="../deps/vorbis/smallft.c" />
+    <ClCompile Include="../deps/vorbis/synthesis.c" />
+    <ClCompile Include="../deps/vorbis/vorbisenc.c" />
+    <ClCompile Include="../deps/vorbis/vorbisfile.c" />
+    <ClCompile Include="../deps/vorbis/window.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{B4A07901-6615-4460-B907-5F0A2838AC34}</ProjectGuid>
+    <RootNamespace>vorbis</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Multibyte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Multibyte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)/msbuild/lib/$(Platform)_$(Configuration)/</OutDir>
+    <IntDir>$(SolutionDir)/msbuild/obj/$(Platform)_$(Configuration)/$(ProjectName)/</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);../deps</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="lutro_build.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Steps to build Lutro on Windows using Visual Studio:
 - make vcxproj  (requires MSYS2 or make installed for Git BASH)
 - load lutro.sln

You can do these in either order, but the project will fail to load without running make.

### Rationale
 - Provides access to Visual Studio debugging symbols and MSVC debugger
 - _(full stop: this alone was worth all this effort for me)_

### Possible alternative
 - figure out how to get *clang-cl* to work, which can also generate PDB files -- but it's actually more work than this, because the command line options for microsoft's cl.exe are such a pita to work with from the context of a makefile. The best idea is probably to write a tool that accepts and parses a gcc/clang command line and translates it (as best as possible) into cl.exe command line. Anything else will require a near-full rewrite of the Makefile, which sucks.

(note that such a tool would be _super cool_ and would benefit roughly 5 million cross-platform open source projects, but it would also be a ton of work)