### PR TITLE
Cleanup fprintf(stderr) usage, remove a lot of spurious fflush calls

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -253,7 +253,6 @@ void lutro_audio_deinit()
    if (counted)
    {
       fprintf(stderr, "Found %d leaked audio source references. Was lua_close() called first?\n", counted);
-      fflush(stderr);
       //assert(false);
       return;
    }
@@ -497,7 +496,6 @@ int source_seek(lua_State *L)
          // TODO: it'd be nice to log with the full lua FILE(LINE): context that's normally prefixed by lua_error,
          // in a manner that allows us to log it without stopping the system. --jstine
          fprintf(stderr, "WAV decoder seek failed: %s\n", strerror(errno));
-         fflush(stdout);
       }
       self->sndpos = decWav_sampleTell(self->wavData);
    }
@@ -519,7 +517,6 @@ int source_seek(lua_State *L)
    {
       // the underlying media source will fixup the seek position...
       fprintf(stderr, "warning: seek asked for sample pos %jd, got pos %jd\n", npSamples, self->sndpos);
-      fflush(stderr);
    }
    return 0;
 }
@@ -556,7 +553,6 @@ int source_gc(lua_State *L)
    if (leaks)
    {
       fprintf(stderr, "source_gc: playing audio references were nullified.\n");
-      fflush(stderr);
       //assert(false);
    }
    

--- a/decoder.c
+++ b/decoder.c
@@ -4,7 +4,6 @@
 #include <errno.h>
 #include <string.h>
 #include <assert.h>
-#include <errno.h>
 
 #include "decoder.h"
 #include "audio.h"
@@ -37,7 +36,7 @@ bool decOgg_init(dec_OggData *data, const char *filename)
    data->info = NULL;
    if (ov_fopen(filename, &data->vf) < 0)
    {
-      printf("Failed to open vorbis file: %s", filename);
+      fprintf(stderr, "Failed to open vorbis file: %s\n", filename);
       return false;
    }
 
@@ -47,7 +46,7 @@ bool decOgg_init(dec_OggData *data, const char *filename)
    data->info = (vorbis_info*)ov_info(&data->vf, 0);
    if (!data->info)
    {
-      printf("couldn't get info for file");
+      fprintf(stderr, "couldn't get info for file\n");
       return false;
    }
 
@@ -56,13 +55,13 @@ bool decOgg_init(dec_OggData *data, const char *filename)
 
    if (data->info->channels != 1 && data->info->channels != 2)
    {
-      printf("unsupported number of channels\n");
+      fprintf(stderr, "unsupported number of channels\n");
       return false;
    }
    
    if (data->info->rate != 44100)
    {
-      printf("unsupported sample rate\n");
+      fprintf(stderr, "unsupported sample rate\n");
       return false;
    }
 
@@ -114,7 +113,7 @@ bool decOgg_decode(dec_OggData *data, presaturate_buffer_desc *buffer, float vol
 
       if (ret < 0)
       {
-         printf("Vorbis decoding failed with: %jd\n", ret);
+         fprintf(stderr, "Vorbis decoding failed with: %jd\n", ret);
          return true;
       }
 
@@ -211,14 +210,12 @@ bool decWav_init(dec_WavData *data, const char *filename)
          return 0;
 
       fprintf(stderr, "Failed to open wavfile '%s': %s\n", filename, strerror(err));
-      fflush(stderr);
       return 0;
    }
 
    if (fread(&data->head, WAV_HEADER_SIZE, 1, fp) == 0)
    {
       fprintf(stderr, "%s is not a valid wav file or is truncated.\n", filename);
-      fflush(stderr);
       fclose(fp);
       return 0;
    }
@@ -252,7 +249,6 @@ bool decWav_seek(dec_WavData *data, intmax_t samplepos)
       // logging here could be unnecessarily spammy. If we add a log it should be gated by
       // some audio diagnostic output switch/mode.
       //fprintf(stderr, "WAV decoder seek failed: %s\n", strerror(errno));
-      //fflush(stdout);
       return 0;
    }
    data->pos = samplepos * bps;
@@ -276,7 +272,6 @@ intmax_t decWav_sampleTell(dec_WavData *data)
             data->head.NumChannels,
             ret
          );
-         fflush(stderr);
       }
    }
    return ret / bps;


### PR DESCRIPTION
I plan to use a forcedinclude on msvc to fix its bad printf behavior in a way that is non-intrusive for all other platforms.
