### PR TITLE
audio: use rawgeti instead of gettable (perf)

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -36,10 +36,9 @@ audio_Source* getSourcePtrFromRef(lua_State* L, audioSourceByRef ref)
       return NULL;
 
    lua_getglobal(L, "refs_audio_playing");
-   lua_pushinteger(L, ref.lua_ref);
-   lua_gettable(L, -2);
+   lua_rawgeti(L, -1, ref.lua_ref);
    audio_Source* result = lua_touserdata(L, -1);
-   lua_pop(L,2);
+   lua_pop(L,1);
    return result;
 }
 


### PR DESCRIPTION
rawgeti bypasses metatable lookups (index overloading, essentially). We don't need to care about it.

Mostly this is pedantic, mostly that looking up refs in lua should probably always use rawgeti because it doesn't make sense to overload the behavior of ref tracking. Probably nothing good could ever come of it.

The perf improvement is negligible. 99% of the overhead is mixing the samples, not reading the sourcedata pointer from lua. 