### PR TITLE
Add lua backtrace info to lutro_error/alter/assert

### DIFF
--- a/lutro_assert.h
+++ b/lutro_assert.h
@@ -48,19 +48,19 @@ typedef enum
 
 extern int _lutro_assertf_internal(int ignorable, const char *fmt, ...);
 
-#define _base_hard_error()                            ((void)(          ((_lutro_assertf_internal(AssertUnrecoverable, __FILE__ "(%d):unrecoverable error "        "\n", __LINE__                        ),1) && (abort(), 0))))
-#define _base_hard_errorf(msg, ...)                   ((void)(          ((_lutro_assertf_internal(AssertUnrecoverable, __FILE__ "(%d):unrecoverable error "    msg "\n", __LINE__,         ## __VA_ARGS__),1) && (abort(), 0))))
-#define _base_soft_alert()                            ((void)(          ((_lutro_assertf_internal(AssertIgnorable,     __FILE__ "(%d):alert "                      "\n", __LINE__                        )  ) && (abort(), 0))))
-#define _base_soft_alertf(msg, ...)                   ((void)(          ((_lutro_assertf_internal(AssertIgnorable,     __FILE__ "(%d):alert "                  msg "\n", __LINE__,         ## __VA_ARGS__)  ) && (abort(), 0))))
-#define _base_soft_error()                            ((void)(          ((_lutro_assertf_internal(AssertErrorOnly,     __FILE__ "(%d):error "                      "\n", __LINE__                        ),0)                )))
-#define _base_soft_errorf(msg, ...)                   ((void)(          ((_lutro_assertf_internal(AssertErrorOnly,     __FILE__ "(%d):error "                  msg "\n", __LINE__,         ## __VA_ARGS__),0)                )))
-#define _base_cond_error(cond)                        ((void)((cond) || ((_lutro_assertf_internal(AssertErrorOnly,     __FILE__ "(%d):assertion `%s` failed. "     "\n", __LINE__, #cond                 ),0)                )))
-#define _base_cond_errorf(cond, msg, ...)             ((void)((cond) || ((_lutro_assertf_internal(AssertErrorOnly,     __FILE__ "(%d):assertion `%s` failed. " msg "\n", __LINE__, #cond , ## __VA_ARGS__),0)                )))
-
-#define _base_hard_assert(cond)                       ((void)((cond) || ((_lutro_assertf_internal(AssertUnrecoverable, __FILE__ "(%d):assertion `%s` failed. "     "\n", __LINE__, #cond                 ),1) && (abort(), 0))))
-#define _base_hard_assertf(cond, msg, ...)            ((void)((cond) || ((_lutro_assertf_internal(AssertUnrecoverable, __FILE__ "(%d):assertion `%s` failed. " msg "\n", __LINE__, #cond , ## __VA_ARGS__),1) && (abort(), 0))))
-#define _base_soft_assert(cond)                       ((void)((cond) || ((_lutro_assertf_internal(AssertIgnorable,     __FILE__ "(%d):assertion `%s` failed. "     "\n", __LINE__, #cond                 )  ) && (abort(), 0))))
-#define _base_soft_assertf(cond, msg, ...)            ((void)((cond) || ((_lutro_assertf_internal(AssertIgnorable,     __FILE__ "(%d):assertion `%s` failed. " msg "\n", __LINE__, #cond , ## __VA_ARGS__)  ) && (abort(), 0))))
+#define _base_hard_error()                            ((void)(          ((_lutro_assertf_internal(AssertUnrecoverable, __FILE__ "(%d): unrecoverable error "        "\n", __LINE__                        ),1) && (abort(), 0))))
+#define _base_hard_errorf(msg, ...)                   ((void)(          ((_lutro_assertf_internal(AssertUnrecoverable, __FILE__ "(%d): unrecoverable error "    msg "\n", __LINE__,         ## __VA_ARGS__),1) && (abort(), 0))))
+#define _base_soft_alert()                            ((void)(          ((_lutro_assertf_internal(AssertIgnorable,     __FILE__ "(%d): alert "                      "\n", __LINE__                        )  ) && (abort(), 0))))
+#define _base_soft_alertf(msg, ...)                   ((void)(          ((_lutro_assertf_internal(AssertIgnorable,     __FILE__ "(%d): alert "                  msg "\n", __LINE__,         ## __VA_ARGS__)  ) && (abort(), 0))))
+#define _base_soft_error()                            ((void)(          ((_lutro_assertf_internal(AssertErrorOnly,     __FILE__ "(%d): error "                      "\n", __LINE__                        ),0)                )))
+#define _base_soft_errorf(msg, ...)                   ((void)(          ((_lutro_assertf_internal(AssertErrorOnly,     __FILE__ "(%d): error "                  msg "\n", __LINE__,         ## __VA_ARGS__),0)                )))
+#define _base_cond_error(cond)                        ((void)((cond) || ((_lutro_assertf_internal(AssertErrorOnly,     __FILE__ "(%d): assertion `%s` failed. "     "\n", __LINE__, #cond                 ),0)                )))
+#define _base_cond_errorf(cond, msg, ...)             ((void)((cond) || ((_lutro_assertf_internal(AssertErrorOnly,     __FILE__ "(%d): assertion `%s` failed. " msg "\n", __LINE__, #cond , ## __VA_ARGS__),0)                )))
+                                                                                                                                       
+#define _base_hard_assert(cond)                       ((void)((cond) || ((_lutro_assertf_internal(AssertUnrecoverable, __FILE__ "(%d): assertion `%s` failed. "     "\n", __LINE__, #cond                 ),1) && (abort(), 0))))
+#define _base_hard_assertf(cond, msg, ...)            ((void)((cond) || ((_lutro_assertf_internal(AssertUnrecoverable, __FILE__ "(%d): assertion `%s` failed. " msg "\n", __LINE__, #cond , ## __VA_ARGS__),1) && (abort(), 0))))
+#define _base_soft_assert(cond)                       ((void)((cond) || ((_lutro_assertf_internal(AssertIgnorable,     __FILE__ "(%d): assertion `%s` failed. "     "\n", __LINE__, #cond                 )  ) && (abort(), 0))))
+#define _base_soft_assertf(cond, msg, ...)            ((void)((cond) || ((_lutro_assertf_internal(AssertIgnorable,     __FILE__ "(%d): assertion `%s` failed. " msg "\n", __LINE__, #cond , ## __VA_ARGS__)  ) && (abort(), 0))))
 
 // lutro error reporting. Errors come in two forms:
 //  - error / alert /fail (no condition is provided in the paramters)


### PR DESCRIPTION
The backtraces are not so great in some of my tests. Lua has a bad habit sometimes of obscuring function names. There's sometimes some ways to improve that but I'll have to dig more later and figure out exactly what's going on.

Some examples, taken using the "intentional failure" wavefile in tests/audio:

```wavfile not found: D:\piepacker\lutro\tests\audio\fail.wav
D:\piepacker\lutro\audio.c(672): error Audio source is not playable.
stack traceback:
	D:\piepacker\lutro\tests\audio\main.lua:56: in function 'play_next_sound'
	D:\piepacker\lutro\tests\audio\main.lua:153: in function '?'
	D:\piepacker\lutro\tests\audio\main.lua:253: in function <D:\piepacker\lutro\tests\audio\main.lua:224>
Playing sound 5: fail.ogg
vorbis file not found: D:\piepacker\lutro\tests\audio\fail.ogg
D:\piepacker\lutro\audio.c(672): error Audio source is not playable.
stack traceback:
	D:\piepacker\lutro\tests\audio\main.lua:56: in function 'play_next_sound'
	D:\piepacker\lutro\tests\audio\main.lua:153: in function '?'
	D:\piepacker\lutro\tests\audio\main.lua:253: in function <D:\piepacker\lutro\tests\audio\main.lua:224>
```