### PR TITLE
Fix the on-purpose audio test error being reported as a segfault

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -633,7 +633,9 @@ int audio_play(lua_State *L)
 
    if (!sourceIsPlayable(self))
    {
-      lutro_alertf("Audio source is not playable.", self->state);
+      lutro_errorf("Audio source is not playable.", self->state);
+      self->state = AUDIO_STOPPED;
+      return 0;
    }
 
    if (self->state == AUDIO_PAUSED)


### PR DESCRIPTION
Just change lutro_alert -> lutro_error

(alerts are not fully implemented yet, so they behave same as an assert which is to generate a segfault for debugging. Eventually, a dialog/popup type thing will replace that. But in either case I only want the unit test to log, not popup errors)