### PR TITLE
Painter updates: scaling (HAVE_SCALING=1) and clip rect on clear

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -152,6 +152,10 @@ ifeq ($(HAVE_COMPOSITION),1)
     CFLAGS += -DHAVE_COMPOSITION
 endif
 
+ifeq ($(HAVE_TRANSFORM),1)
+    CFLAGS += -DHAVE_TRANSFORM
+endif
+
 # PhysFS
 ifeq ($(WANT_PHYSFS), 1)
    DEFINES += -DWANT_PHYSFS

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Compile Lutro by [installing the RetroArch dependencies](https://github.com/libr
 There are a few optional defines you can use to change how Lutro behaves.
 
 - `make HAVE_COMPOSITION=1` Enables alpha-blending.
-
+- `make HAVE_TRANSFORM=1` Enables scaling
 
 ## Test
 

--- a/graphics.c
+++ b/graphics.c
@@ -919,9 +919,17 @@ static int gfx_draw(lua_State *L)
    // int kx = OPTNUMBER(L, start + 8, 0);
    // int ky = OPTNUMBER(L, start + 9, 0);
 
+#ifndef HAVE_TRANSFORM
+   // if transformations are not enabled, we set them to default values here
+   // in order to prevent them from having any unexpected effects whatsoever.
+   sx = 1;
+   sy = 1;
+   r = 0;
+#endif
+
    rect_t drect = {
-      x + ox,
-      y + oy,
+      x - ox * sx,
+      y - oy * sy,
       (int)data->width,
       (int)data->height
    };

--- a/lutro.c
+++ b/lutro.c
@@ -234,6 +234,31 @@ static void init_settings(lua_State *L)
    lua_pop(L, 1);
 }
 
+// reveals which configuration options were used to compile lutro.
+static void init_config(lua_State *L)
+{
+   lutro_ensure_global_table(L, "lutro");
+
+   lua_newtable(L);
+
+   #define STR(a) #a
+   #define CAPABILITY(_cap_)                           \
+      lua_pushboolean(L, strcmp(STR(_cap_), #_cap_));  \
+      lua_setfield(L, -2, #_cap_);
+
+   CAPABILITY(HAVE_COMPOSITION);
+   CAPABILITY(HAVE_TRANSFORM);
+   CAPABILITY(HAVE_INOTIFY);
+   CAPABILITY(HAVE_JIT);
+   CAPABILITY(HAVE_LUASOCKET);
+
+   #undef STR
+   #undef CAPABILITY
+
+   lua_setfield(L, -2, "config");
+   lua_pop(L, 1);
+}
+
 void lutro_init()
 {
    L = luaL_newstate();
@@ -250,6 +275,8 @@ void lutro_init()
    lutro_checked_stack_begin();
 
    init_settings(L);
+
+   init_config(L);
 
    lutro_preload(L, lutro_core_preload, "lutro");
    lutro_preload(L, lutro_image_preload, "lutro.image");

--- a/painter.c
+++ b/painter.c
@@ -46,12 +46,31 @@ void pntr_reset(painter_t *p)
 
 void pntr_clear(painter_t *p)
 {
-   uint32_t *begin = p->target->data;
-   uint32_t *end   = p->target->data + p->target->height * (p->target->pitch >> 2);
    uint32_t color  = p->background;
 
-   while (begin < end)
-      *begin++ = color;
+   if (p->clip.x == 0 && p->clip.width == p->target->width
+      && p->clip.y == 0 && p->clip.height == p->target->height)
+   {
+      // this loop might be optimized by the compiler in comparison with
+      // the alternative loop below.
+      uint32_t *begin = p->target->data;
+      uint32_t *end   = p->target->data + p->target->height * (p->target->pitch >> 2);
+      while (begin < end)
+      {
+         *begin++ = color;
+      }
+   }
+   else
+   {
+      // less efficient loop than above, but can handle clipping rect.
+      for (uint32_t x = MAX(0, p->clip.x); x < MIN(p->clip.x + p->clip.width, p->target->width); ++x)
+      {
+         for (uint32_t y = MAX(0, p->clip.y); y < MAX(p->clip.y + p->clip.height, y < p->target->height); ++y)
+         {
+            p->target->data[x + y * (p->target->pitch >> 2)] = color;
+         }
+      }
+   }
 }
 
 

--- a/painter.c
+++ b/painter.c
@@ -306,10 +306,10 @@ void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const 
 {
    rect_t srect = *src_rect, drect = *dst_rect;
 
-#ifdef HAVE_TRANSFORM
-   drect.x += p->trans->tx * p->trans->sx;
-   drect.y += p->trans->ty * p->trans->sy;
+   drect.x += p->trans->tx;
+   drect.y -= p->trans->ty;
 
+#ifdef HAVE_TRANSFORM
    // stored as 0 or 0xffffffff for masking properties.
    const uint32_t is_x_reversed = (p->trans->sx < 0) ? 0xffffffff : 0;
    const uint32_t is_y_reversed = (p->trans->sy < 0) ? 0xffffffff : 0;
@@ -342,9 +342,6 @@ void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const 
       drect.y -= drect.height;
    }
 #else
-   drect.x += p->trans->tx;
-   drect.y += p->trans->ty;
-
    drect.width  = srect.width;
    drect.height = srect.height;
 

--- a/painter.c
+++ b/painter.c
@@ -291,14 +291,27 @@ void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const 
    drect.x += p->trans->tx * p->trans->sx;
    drect.y += p->trans->ty * p->trans->sy;
 
-   uint32_t is_x_reversed = p->trans->sx < 0;
-   uint32_t is_y_reversed = p->trans->sy < 0;
+   // stored as 0 or 0xffffffff for masking properties.
+   const uint32_t is_x_reversed = (p->trans->sx < 0) ? 0xffffffff : 0;
+   const uint32_t is_y_reversed = (p->trans->sy < 0) ? 0xffffffff : 0;
 
    float abs_sx = is_x_reversed ? -p->trans->sx : p->trans->sx;
    float abs_sy = is_y_reversed ? -p->trans->sy : p->trans->sy;
 
    drect.width  = srect.width * abs_sx;
    drect.height = srect.height * abs_sy;
+
+   const uint32_t k_binexp = 16;
+   const uint32_t k_binexp_center = (1 << (k_binexp - 1));
+
+   // give up if scaling is small enough that division becomes untenable
+   if (abs_sx < 1.0/k_binexp_center || abs_sy < 1.0/k_binexp_center)
+      return;
+   
+   const uint32_t inv_scale_x = (1 << k_binexp) / abs_sx;
+   const uint32_t inv_scale_y = (1 << k_binexp) / abs_sy;
+
+   #define SCALE_DST_TO_SRC(axis, a) (((a) * inv_scale_##axis + k_binexp_center) >> k_binexp)
 
    // negative scaling reverses the top-left and bottom-right corners like so:
    if (is_x_reversed)
@@ -315,27 +328,75 @@ void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const 
 
    drect.width  = srect.width;
    drect.height = srect.height;
+
+   #define SCALE_DST_TO_SRC(axis, a) (a)
+   #define is_x_reversed 0
+   #define is_y_reversed 0
 #endif
 
    // crop source rect to destination
    if (drect.x < 0)
    {
-      srect.x     += -drect.x;
-      srect.width += drect.x;
+      srect.width += SCALE_DST_TO_SRC(x, drect.x);
+      if (!is_x_reversed)
+      {
+         // (crop from left side of source)
+         srect.x  += SCALE_DST_TO_SRC(x, -drect.x);
+      }
+      drect.width += drect.x;
+      drect.x      = 0;
    }
 
    if (drect.y < 0)
    {
-      srect.y      += -drect.y;
-      srect.height += drect.y;
+      srect.height += SCALE_DST_TO_SRC(y, drect.y);
+      if (!is_y_reversed)
+      {
+         // (crop from top of source)
+         srect.y   += SCALE_DST_TO_SRC(y, -drect.y);
+      }
+      drect.height += drect.y;
+      drect.y       = 0;
    }
 
-   drect        = rect_intersect(&drect, &p->clip);
+   rect_t drect_clipped = rect_intersect(&drect, &p->clip);
 
-#ifndef HAVE_TRANSFORM
-   drect.width  = MIN(drect.width, srect.width);
-   drect.height = MIN(drect.height, srect.height);
-#endif
+   // (note: this can never be negative, so srect.x, srect.y remain positive)
+   srect.x      += SCALE_DST_TO_SRC(x, drect_clipped.x      - drect.x);
+   srect.width  -= SCALE_DST_TO_SRC(x, drect.width - drect_clipped.width);
+   srect.y      += SCALE_DST_TO_SRC(y, drect_clipped.y      - drect.y);
+   srect.height -= SCALE_DST_TO_SRC(y, drect.height - drect_clipped.height);
+
+   drect = drect_clipped;
+
+   // ensure source rect is cropped to source bounds
+   if (srect.x + srect.width > bmp->width)
+   {
+      srect.width = bmp->width - srect.x;
+   }
+   if (srect.y + srect.height > bmp->height)
+   {
+      srect.height = bmp->height - srect.y;
+   }
+
+   // ensure we won't exceed the bitmap's data during the upcoming blit:
+   #ifdef HAVE_TRANSFORM
+      // temporary implementation
+      // TODO: replace this.
+      if (srect.x >= bmp->width || srect.y >= bmp->height)
+         return;
+      while (srect.x + SCALE_DST_TO_SRC(x, drect.width) > bmp->width)
+      {
+         drect.width--;
+      }
+      while (srect.y + SCALE_DST_TO_SRC(y, drect.height) > bmp->height)
+      {
+         drect.height--;
+      }
+   #else
+      drect.width = MIN(drect.width, srect.width);
+      drect.height = MIN(drect.height, srect.height); 
+   #endif
 
    if (rect_is_null(&drect) || rect_is_null(&srect) || p->trans->sx == 0 || p->trans->sy == 0)
       return;
@@ -351,10 +412,6 @@ void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const 
    int x = 0;
 
 #ifdef HAVE_TRANSFORM
-   const uint32_t k_binexp = 16;
-   const uint32_t k_binexp_centre = (1 << (k_binexp - 1));
-   const uint32_t inv_scale_x = (1 << k_binexp) / abs_sx;
-   const uint32_t inv_scale_y = (1 << k_binexp) / abs_sy;
    uint32_t y = 0;
 #endif
 #ifdef HAVE_COMPOSITION
@@ -369,8 +426,8 @@ void pntr_draw(painter_t *p, const bitmap_t *bmp, const rect_t *src_rect, const 
 #ifdef HAVE_TRANSFORM
          uint32_t xo = (x & ~is_x_reversed) | ((cols - x - 1) & is_x_reversed);
          uint32_t yo = (y & ~is_y_reversed) | ((drect.height - y - 1) & is_y_reversed);
-         uint32_t xi = (uint32_t)(xo * inv_scale_x + k_binexp_centre) >> k_binexp;
-         uint32_t yi = (uint32_t)(yo * inv_scale_y + k_binexp_centre) >> k_binexp;
+         uint32_t xi = SCALE_DST_TO_SRC(x, xo);
+         uint32_t yi = SCALE_DST_TO_SRC(y, yo);
          s = src[xi + yi * src_skip];
 #else
          s = src[x];

--- a/test/graphics/scale.lua
+++ b/test/graphics/scale.lua
@@ -1,0 +1,72 @@
+local t, rotation, scale_x, scale_y, org_x, org_y, src_x, src_w = 0, 0, 0, 0, 0, 0, 0, 0
+local draw_line = false
+local line_segments = {}
+local img = nil
+
+return {
+	load = function()
+		img = lutro.graphics.newImage("graphics/font.png")
+		line_segments[1] = {x=104, y=108} -- 100 + centred on quad
+	end,
+
+	draw = function()
+		lutro.graphics.setColor(255, 255, 255)
+
+		-- track scaling-offset interaction using a line
+		if draw_line then
+			lutro.graphics.print("Image should follow the line:", 40, 80)
+			line_segments[#line_segments + 1] = {x=104 - scale_x * org_x, y=108 - scale_y * org_y}
+			for idx, coord in ipairs(line_segments) do
+				if idx > 1 then
+					local prevcoord = line_segments[idx - 1]
+					lutro.graphics.line(prevcoord.x, prevcoord.y, coord.x, coord.y)
+				end
+			end
+		end
+
+		lutro.graphics.draw(img,
+			lutro.graphics.newQuad( src_x, 0, src_w, 16, img:getWidth(), img:getHeight()),
+			100, 100,
+			rotation,
+			scale_x,
+			scale_y,
+			org_x,
+			org_y
+		)
+	end,
+
+	update = function(dt)
+		-------------------------------------------
+		-- Set parameters based on current time. --
+		-------------------------------------------
+		t = t + dt
+
+		-- rotation not supported, so we leave it as zero.
+		rotation = 0
+
+		scale_x = 1 + math.sin(t * 3) * 4
+		scale_y = math.cos(t * 2) * 2
+
+		-- test zero scaling (should be blank)
+		if t < 0.2 then
+			scale_x = 0
+			scale_y = 0
+		end
+		
+		-- image offset while scaled
+		if t > 1.5 then
+			-- set xscale, yscale to something arbitrary
+			-- then ensure origin is offset correctly by scale
+			scale_x = 2.5 - math.pow(t - 1.5, 9)
+			scale_y = 1.1 + math.pow(t - 1.5, 7)
+			org_x = -(t - 1.5) * 100
+			org_y = org_x + math.sin((t - 1.5) * 8) * 20
+			-- (origin should follow the line being drawn)
+			draw_line = true
+		end
+
+		-- src position
+		src_x = 9 * math.floor(t + 1)
+		src_w = 8
+	end
+}

--- a/test/main.lua
+++ b/test/main.lua
@@ -5,6 +5,7 @@ local availableStates = {
 	"joystick/isDown",
 	"graphics/rectangle",
 	"graphics/line",
+	"graphics/scale",
 	"audio/play",
 	"joystick/getJoystickCount",
 	"window/close"

--- a/test/main.lua
+++ b/test/main.lua
@@ -5,7 +5,8 @@ local availableStates = {
 	"joystick/isDown",
 	"graphics/rectangle",
 	"graphics/line",
-	"graphics/scale",
+	-- ignore this test if lutro compiled without HAVE_TRANSFORM:
+  lutro.config.HAVE_TRANSFORM and "graphics/scale" or false,
 	"audio/play",
 	"joystick/getJoystickCount",
 	"window/close"
@@ -22,9 +23,11 @@ function lutro.load()
 
 	-- Initiate all available test states.
 	for i, state in ipairs(availableStates) do
-		local test = require(state)
-		test['name'] = "lutro." .. string.gsub(state, "/", ".")
-		table.insert(states, test)
+		if state then
+			local test = require(state)
+			test['name'] = "lutro." .. string.gsub(state, "/", ".")
+			table.insert(states, test)
+		end
 	end
 
 	-- Load all states.


### PR DESCRIPTION
## Summary

- `pntr_clear` is now affected by the clip rect, as per [the love 2d api documentation](https://love2d.org/wiki/love.graphics.clear).
- build with `make HAVE_SCALING=1` to enable scaling in `pntr_draw`. (This allows images to be scaled when drawn)
- draw offset is applied correctly now (subtracted, not added)