### PR TITLE
Add lutro.filesystem.getAppdataDirectory()

### DIFF
--- a/filesystem.c
+++ b/filesystem.c
@@ -24,6 +24,7 @@ int lutro_filesystem_preload(lua_State *L)
       { "load",        fs_load },
       { "setIdentity", fs_setIdentity },
       { "getUserDirectory", fs_getUserDirectory },
+      { "getAppdataDirectory", fs_getAppdataDirectory },
       { "isDirectory", fs_isDirectory },
       { "isFile",      fs_isFile },
       { "createDirectory", fs_createDirectory },
@@ -228,6 +229,26 @@ int fs_getUserDirectory(lua_State *L)
 
    lua_pushstring(L, homedir);
 
+   return 1;
+}
+
+/**
+ * lutro.filesystem.getAppdataDirectory
+ *
+ * Retrieves libretro's SYSTEM directory.
+ *
+ * @see https://love2d.org/wiki/love.filesystem.getAppdataDirectory
+ * @see RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY
+ */
+int fs_getAppdataDirectory(lua_State *L)
+{
+   char* appdataDir;
+   if ((*settings.environ_cb)(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &appdataDir)) {
+      lua_pushstring(L, appdataDir);
+   }
+   else {
+      lua_pushstring(L, "");
+   }
    return 1;
 }
 

--- a/filesystem.h
+++ b/filesystem.h
@@ -22,6 +22,7 @@ int fs_isFile(lua_State *L);
 int fs_isDirectory(lua_State *L);
 int fs_createDirectory(lua_State *L);
 int fs_getUserDirectory(lua_State *L);
+int fs_getAppdataDirectory(lua_State *L);
 int fs_getDirectoryItems(lua_State *L);
 
 #endif // FILESYSTEM_H

--- a/test/unit/modules/filesystem.lua
+++ b/test/unit/modules/filesystem.lua
@@ -14,6 +14,11 @@ function lutro.filesystem.getRequirePathTest()
     unit.assertEquals(paths, package.path)
 end
 
+function lutro.filesystem.getAppdataDirectoryTest()
+    local appdataDir = lutro.filesystem.getAppdataDirectory()
+    unit.assertIsString(appdataDir)
+end
+
 function lutro.filesystem.getUserDirectoryTest()
     local homeDir = lutro.filesystem.getUserDirectory()
     -- @todo Find out how to make os.getenv('HOME') work on Windows?
@@ -49,6 +54,7 @@ return {
     lutro.filesystem.setRequirePathTest,
     lutro.filesystem.getRequirePathTest,
     lutro.filesystem.getUserDirectoryTest,
+    lutro.filesystem.getAppdataDirectoryTest,
     lutro.filesystem.getDirectoryItemsTest,
     lutro.filesystem.isFileTest,
     lutro.filesystem.isDirectoryTest


### PR DESCRIPTION
Getting the system dir seems similar enough to https://love2d.org/wiki/love.filesystem.getAppdataDirectory .

``` lua
local appdataDir = lutro.filesystem.getAppdataDirectory()
appdataDir
--> ~/.config/retroarch/system
```

Fixes #226