### PR TITLE
fix stackframe leaks caused by lua_isfunction checks

### DIFF
--- a/keyboard.c
+++ b/keyboard.c
@@ -186,6 +186,7 @@ void lutro_keyboardevent(lua_State* L)
    ENTER_LUA_STACK
    int16_t is_down;
 
+   lutro_ensure_global_table(L, "lutro");
    for (unsigned i = 0; i < RETROK_LAST; i++)
    {
       // Check if the keyboard key is pressed
@@ -194,11 +195,9 @@ void lutro_keyboardevent(lua_State* L)
       is_down = settings.input_cb(0, RETRO_DEVICE_KEYBOARD, 0, i);
 
       if (is_down != keyboard_cache[i]) {
-         lua_getglobal(L, "lutro");
          lua_getfield(L, -1, is_down ? "keypressed" : "keyreleased");
-         if (lua_isfunction(L, -1))
+         if (lutro_pcall_isfunction(L, -1))
          {
-            lua_pushcfunction(L, traceback);  // could put this in outer loop, but kdb state changes are uncommon
             // Set up the arguments.
             lua_pushstring(L, keyboard_find_name(keyboard_enum, i)); // KeyConstant key
             lua_pushnumber(L, i); // Scancode scancode
@@ -211,14 +210,13 @@ void lutro_keyboardevent(lua_State* L)
                fprintf(stderr, "%s\n", lua_tostring(L, -1));
                lua_pop(L, 1);
             }
-            lua_pop(L, 1);
          }
-         lua_pop(L, 2);
 
          // Update the keyboard state.
          keyboard_cache[i] = is_down;
       }
    }
+   lua_pop(L, 1);    // pop lutro
    EXIT_LUA_STACK
 }
 

--- a/runtime.h
+++ b/runtime.h
@@ -92,5 +92,6 @@ void luax_setfuncs(lua_State *L, const luaL_Reg *l);
 
 int traceback(lua_State *L);
 int lutro_pcall(lua_State *L, int narg, int nret);
+int lutro_pcall_isfunction(lua_State* L, int idx);
 
 #endif // RUNTIME_H


### PR DESCRIPTION
`lua_isfunction()` == false wouldn't remove the element from the stack, but lua_pcall did remove it from the stack in the case that `lua_isfunction() == true`. This caused the majority of stackframe leaks that had been vexing the engine.

To fix the issue I added a helper function `lua_pcall_isfunction()` which behaves in a way that is consistent with lua_pcall usage. In this way, both function execution paths will leave the stack in an expected state.

The alternative approach was to add `else { lua_pop(L, 1); }` to all calls to `lua_isfunction()` ... though given the frequency of this particular idiom it seemed worthwhile to give it a function helper.

Also, expanded use of `lutro_ensure_global_table()` to fix some minor issues when authoring new libretro frontends for lutro. There were cases where the API would hard-crash due to the lutro table missing, and there is no drawback to using `lutro_ensure_global_table()` prettymcuh everywhere.