### PR TITLE
pcall: optimize traceback provision

### DIFF
--- a/joystick.c
+++ b/joystick.c
@@ -56,8 +56,6 @@ void lutro_joystickevent(lua_State* L)
    int i, u;
    int16_t state;
 
-   lua_pushcfunction(L, traceback);
-
    // Loop through each joystick.
    for (i = 0; i < NB_JOYSTICKS; i++) {
       // Loop through each button.
@@ -83,7 +81,6 @@ void lutro_joystickevent(lua_State* L)
       joystick_cache[i][16] = settings.input_cb(i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
       joystick_cache[i][17] = settings.input_cb(i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
    }
-   lua_pop(L, 1); // pop traceback
    EXIT_LUA_STACK
 }
 

--- a/msbuild/lutro_build.props
+++ b/msbuild/lutro_build.props
@@ -23,6 +23,36 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tool|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Player|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <!-- Release build target is used by vorbis and lua, as these don't care about Tool/Dev builds -->
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -33,9 +63,5 @@
       <ConformanceMode>true</ConformanceMode>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-    </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/runtime.c
+++ b/runtime.c
@@ -85,7 +85,7 @@ int lutro_require(lua_State *L, const char *modname, int pop_result)
    lua_getglobal(L, "require");
    lua_pushstring(L, modname);
 
-   int success = lua_pcall(L, 1, 1, 0) == 0;
+   int success = lutro_pcall(L, 1, 1) == 0;
 
    if (success && pop_result)
       lua_pop(L, 1);


### PR DESCRIPTION
It is now pushed once on init and reused there-after. This was my intention from the time I started this traceback refactor a few years ago. Better late than never.

Tested using the tests/audio/main.lua, which intentionally loads broken oggfiles and generates traceback stacktraces as a result.