### PR TITLE
Consolidate stack checking macros and stackdump functions

### DIFF
--- a/joystick.c
+++ b/joystick.c
@@ -52,9 +52,10 @@ void lutro_joystick_init()
 
 void lutro_joystickevent(lua_State* L)
 {
-   ENTER_LUA_STACK
    int i, u;
    int16_t state;
+
+   tool_checked_stack_begin(L);
 
    // Loop through each joystick.
    for (i = 0; i < NB_JOYSTICKS; i++) {
@@ -81,7 +82,8 @@ void lutro_joystickevent(lua_State* L)
       joystick_cache[i][16] = settings.input_cb(i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
       joystick_cache[i][17] = settings.input_cb(i, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
    }
-   EXIT_LUA_STACK
+
+   tool_checked_stack_end(L, 0);
 }
 
 /**
@@ -170,7 +172,7 @@ int joystick_isDown(lua_State *L)
  */
 int joystick_getAxis(lua_State *L)
 {
-   ENTER_LUA_STACK
+   tool_checked_stack_begin(L);
    int n = lua_gettop(L);
    if (n != 2) {
       return luaL_error(L, "lutro.joystick.getAxis requires two arguments, %d given.", n);
@@ -183,8 +185,7 @@ int joystick_getAxis(lua_State *L)
 
    lua_pushnumber(L, output);
 
-   return 1;
-   EXIT_LUA_STACK
+   return tool_checked_stack_end(L, 1);
 }
 
 /**

--- a/keyboard.c
+++ b/keyboard.c
@@ -183,8 +183,9 @@ void lutro_keyboard_init()
  */
 void lutro_keyboardevent(lua_State* L)
 {
-   ENTER_LUA_STACK
    int16_t is_down;
+
+   tool_checked_stack_begin(L);
 
    lutro_ensure_global_table(L, "lutro");
    for (unsigned i = 0; i < RETROK_LAST; i++)
@@ -217,7 +218,8 @@ void lutro_keyboardevent(lua_State* L)
       }
    }
    lua_pop(L, 1);    // pop lutro
-   EXIT_LUA_STACK
+   
+   tool_checked_stack_end(L, 0);
 }
 
 /**

--- a/lutro.h
+++ b/lutro.h
@@ -16,16 +16,6 @@
 #define VERSION_PATCH 1
 #define VERSION_STRING "0.0.1"
 
-extern int g_lua_stack;
-#define ENTER_LUA_STACK do { g_lua_stack = lua_gettop(L); } while(0);
-#define EXIT_LUA_STACK do { \
-	int stack = lua_gettop(L); \
-	if (stack != g_lua_stack) { \
-		printf("invalid stack setup (got %d expected %d) on %s\n", stack, g_lua_stack, __func__); \
-		lua_settop(L, g_lua_stack); \
-	} \
-} while (0);
-
 typedef struct lutro_settings_t {
    int width;
    int height;


### PR DESCRIPTION
There ended up two difference versions of these - one which was provided in runtime.h (and had been added long ago to support live.c) and another one in lutro.h which was added more recently in a more hurried fashion. Following additions and changes have been made:

 - remove the g_lua_stack global, which could lead to false-positive asserts in nested call situations
 - avoid the use of double-underscore for the temporary variable (eg `__delta`) which are reserved for use by glibc headers.
 - disable most stack checks in player build (avoid overhead)
 - use out-of-line function to print the stack assertion message (avoids overhead and avoids macro ugliness)
 - add file:line info to the stack assertion message, as this is more reliable than `__func__` across compilers, and can be hyperlinked via most modern console terminal apps