### PR TITLE
streamline lutro table init and lookup, add lutro_newlib

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -247,7 +247,7 @@ void mixer_render(lua_State* L, int16_t *buffer)
 
 int lutro_audio_preload(lua_State *L)
 {
-   static luaL_Reg gfx_funcs[] =  {
+   static const luaL_Reg audio_funcs[] =  {
       { "play",      audio_play },
       { "stop",      audio_stop },
       { "pause",     audio_pause },
@@ -259,11 +259,7 @@ int lutro_audio_preload(lua_State *L)
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, gfx_funcs);
-
-   lua_setfield(L, -2, "audio");
+   lutro_newlib(L, audio_funcs, "audio");
 
    return 1;
 }

--- a/event.c
+++ b/event.c
@@ -8,14 +8,12 @@
 
 int lutro_event_preload(lua_State *L)
 {
-   static luaL_Reg event_funcs[] =  {
+   static const luaL_Reg event_funcs[] =  {
       { "quit", event_quit },
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-   luaL_newlib(L, event_funcs);
-   lua_setfield(L, -2, "event");
+   lutro_newlib(L, event_funcs, "event");
 
    return 1;
 }

--- a/filesystem.c
+++ b/filesystem.c
@@ -15,7 +15,7 @@
 
 int lutro_filesystem_preload(lua_State *L)
 {
-   static luaL_Reg gfx_funcs[] =  {
+   static const luaL_Reg fs_funcs[] =  {
       { "exists",      fs_exists },
       { "read",        fs_read },
       { "write",       fs_write },
@@ -32,11 +32,7 @@ int lutro_filesystem_preload(lua_State *L)
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, gfx_funcs);
-
-   lua_setfield(L, -2, "filesystem");
+   lutro_newlib(L, fs_funcs, "filesystem");
 
    return 1;
 }

--- a/graphics.c
+++ b/graphics.c
@@ -1188,7 +1188,7 @@ static int gfx_present(lua_State *L)
 
 int lutro_graphics_preload(lua_State *L)
 {
-   static luaL_Reg gfx_funcs[] =  {
+   static const luaL_Reg gfx_funcs[] =  {
       { "clear",        gfx_clear },
       { "draw",         gfx_draw },
       { "getBackgroundColor", gfx_getBackgroundColor },
@@ -1231,11 +1231,7 @@ int lutro_graphics_preload(lua_State *L)
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, gfx_funcs);
-
-   lua_setfield(L, -2, "graphics");
+   lutro_newlib(L, gfx_funcs, "graphics"); 
 
    return 1;
 }

--- a/image.c
+++ b/image.c
@@ -19,14 +19,13 @@ static int l_gc(lua_State *L);
 
 int lutro_image_preload(lua_State *L)
 {
-   static luaL_Reg img_funcs[] =  {
+   static const luaL_Reg img_funcs[] =  {
       { "newImageData", l_newImageData },
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-   luaL_newlib(L, img_funcs);
-   lua_setfield(L, -2, "image");
+   fprintf(stderr, "========= Imagre\n");
+   lutro_newlib(L, img_funcs, "image");
 
    return 1;
 }

--- a/input.c
+++ b/input.c
@@ -50,16 +50,12 @@ const char* input_find_name(const struct int_const_map *map, unsigned value)
 
 int lutro_input_preload(lua_State *L)
 {
-   static luaL_Reg funcs[] =  {
+   static const luaL_Reg funcs[] =  {
       {"joypad", input_joypad},
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, funcs);
-
-   lua_setfield(L, -2, "input");
+   lutro_newlib(L, funcs, "input");
 
    return 1;
 }

--- a/joystick.c
+++ b/joystick.c
@@ -30,18 +30,14 @@ const struct joystick_int_const_map joystick_key_enum[NB_BUTTONS+1] = {
 
 int lutro_joystick_preload(lua_State *L)
 {
-   static luaL_Reg joystick_funcs[] =  {
+   static const luaL_Reg joystick_funcs[] =  {
       { "getJoystickCount", joystick_getJoystickCount },
       { "isDown", joystick_isDown },
       { "getAxis", joystick_getAxis },
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, joystick_funcs);
-
-   lua_setfield(L, -2, "joystick");
+   lutro_newlib(L, joystick_funcs, "joystick");
 
    return 1;
 }

--- a/keyboard.c
+++ b/keyboard.c
@@ -154,18 +154,14 @@ const struct key_int_const_map keyboard_enum[RETROK_LAST] = {
 
 int lutro_keyboard_preload(lua_State *L)
 {
-   static luaL_Reg keyboard_funcs[] =  {
+   static const luaL_Reg keyboard_funcs[] =  {
       { "isDown", keyboard_isDown },
       { "getKeyFromScancode", keyboard_getKeyFromScancode },
       { "getScancodeFromKey", keyboard_getScancodeFromKey },
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, keyboard_funcs);
-
-   lua_setfield(L, -2, "keyboard");
+   lutro_newlib(L, keyboard_funcs, "keyboard");
 
    return 1;
 }
@@ -187,7 +183,7 @@ void lutro_keyboardevent(lua_State* L)
 
    tool_checked_stack_begin(L);
 
-   lutro_ensure_global_table(L, "lutro");
+   lua_getglobal(L, "lutro");
    for (unsigned i = 0; i < RETROK_LAST; i++)
    {
       // Check if the keyboard key is pressed
@@ -217,7 +213,7 @@ void lutro_keyboardevent(lua_State* L)
          keyboard_cache[i] = is_down;
       }
    }
-   lua_pop(L, 1);    // pop lutro
+   lua_pop(L, 1);
    
    tool_checked_stack_end(L, 0);
 }

--- a/lutro_math.c
+++ b/lutro_math.c
@@ -13,17 +13,13 @@ void lutro_math_init()
 
 int lutro_math_preload(lua_State *L)
 {
-   static luaL_Reg math_funcs[] = {
+   static const luaL_Reg math_funcs[] = {
       { "random", lutro_math_random },
       { "setRandomSeed", lutro_math_setRandomSeed },
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, math_funcs);
-
-   lua_setfield(L, -2, "math");
+   lutro_newlib(L, math_funcs, "math");
 
    return 1;
 }

--- a/lutro_window.c
+++ b/lutro_window.c
@@ -9,7 +9,7 @@
 
 int lutro_window_preload(lua_State *L)
 {
-   static luaL_Reg win_funcs[] =  {
+   static const luaL_Reg win_funcs[] =  {
       { "close", win_close },
       { "setTitle", win_setTitle },
       { "setMode",  win_setMode },
@@ -28,11 +28,7 @@ int lutro_window_preload(lua_State *L)
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, win_funcs);
-
-   lua_setfield(L, -2, "window");
+   lutro_newlib(L, win_funcs, "window");
 
    return 1;
 }

--- a/mouse.c
+++ b/mouse.c
@@ -10,7 +10,7 @@ static int16_t mouse_cache[8];
 
 int lutro_mouse_preload(lua_State *L)
 {
-   static luaL_Reg mouse_funcs[] =  {
+   static const luaL_Reg mouse_funcs[] =  {
       { "isDown", mouse_isDown },
       { "getX", mouse_getX },
       { "getY", mouse_getY },
@@ -18,11 +18,7 @@ int lutro_mouse_preload(lua_State *L)
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, mouse_funcs);
-
-   lua_setfield(L, -2, "mouse");
+   lutro_newlib(L, mouse_funcs, "mouse");
 
    return 1;
 }

--- a/runtime.c
+++ b/runtime.c
@@ -22,26 +22,6 @@ int lutro_preload(lua_State *L, lua_CFunction f, const char *name)
    return 0;
 }
 
-int lutro_ensure_global_table(lua_State *L, const char *name)
-{
-   lua_getglobal(L, name);
-
-   if (!lua_istable(L, -1)) {
-      lua_pop(L, 1);
-      lua_newtable(L);
-
-      // Introduce lutro.getVersion().
-      lua_pushcfunction(L, lutro_getVersion);
-      lua_setfield(L, -2, "getVersion");
-
-      // Add the "lutro" Lua global.
-      lua_pushvalue(L, -1);
-      lua_setglobal(L, name);
-   }
-
-   return 1;
-}
-
 void lutro_checked_stack_assert(lua_State* L, int expectedTop, char const* file, int line)
 {
    // TODO: report this error once per file/line, as a means of reducing spam potential

--- a/runtime.h
+++ b/runtime.h
@@ -34,7 +34,6 @@ void lutro_checked_stack_assert(lua_State* L, int expectedTop, char const* file,
 
 
 int lutro_preload(lua_State *L, lua_CFunction f, const char *name);
-int lutro_ensure_global_table(lua_State *L, const char *name);
 void lutro_namespace(lua_State *L);
 void lutro_stack_dump(lua_State *L);
 int lutro_getVersion(lua_State *L);
@@ -95,5 +94,11 @@ void luax_setfuncs(lua_State *L, const luaL_Reg *l);
 int traceback(lua_State *L);
 int lutro_pcall(lua_State *L, int narg, int nret);
 int lutro_pcall_isfunction(lua_State* L, int idx);
+
+void lutro_newlib_x(lua_State* L, luaL_Reg const* funcs, char const* fieldname, int numfuncs);
+#define lutro_newlib(L,funcs,fieldname)  (lutro_newlib_x(L,funcs,fieldname, (sizeof(funcs) / sizeof((funcs)[0]) - 1)))
+
+
+#define luax_reqglobal(L, k)  ((void) (lua_getglobal(L, k), dbg_assertf(lua_istable(L, -1), "missing global table '%s'",k), 0) )
 
 #endif // RUNTIME_H

--- a/sound.c
+++ b/sound.c
@@ -9,16 +9,12 @@
 
 int lutro_sound_preload(lua_State *L)
 {
-   static luaL_Reg snd_funcs[] =  {
+   static const luaL_Reg snd_funcs[] =  {
       { "newSoundData", snd_newSoundData },
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, snd_funcs);
-
-   lua_setfield(L, -2, "sound");
+   lutro_newlib(L, snd_funcs, "sound");
 
    return 1;
 }

--- a/system.c
+++ b/system.c
@@ -11,7 +11,7 @@ const char* clipboardText = "";
 
 int lutro_system_preload(lua_State *L)
 {
-   static luaL_Reg sys_funcs[] =  {
+   static const luaL_Reg sys_funcs[] =  {
       { "getOS", sys_getOS },
       { "getProcessorCount", sys_getProcessorCount },
       { "setClipboardText", sys_setClipboardText },
@@ -22,11 +22,7 @@ int lutro_system_preload(lua_State *L)
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, sys_funcs);
-
-   lua_setfield(L, -2, "system");
+   lutro_newlib(L, sys_funcs, "system");
 
    return 1;
 }

--- a/timer.c
+++ b/timer.c
@@ -6,18 +6,14 @@
 
 int lutro_timer_preload(lua_State *L)
 {
-   static luaL_Reg gfx_funcs[] =  {
+   static const luaL_Reg timer_funcs[] =  {
       { "getTime", timer_getTime },
       { "getDelta", timer_getDelta },
       { "getFPS", timer_getFPS },
       {NULL, NULL}
    };
 
-   lutro_ensure_global_table(L, "lutro");
-
-   luaL_newlib(L, gfx_funcs);
-
-   lua_setfield(L, -2, "timer");
+   lutro_newlib(L, timer_funcs, "timer");
 
    return 1;
 }


### PR DESCRIPTION
Primary function change is that this avoids situations where a lutro table could be created without adding getVersion. It also removes a function that had a generic argument for table name, but performed actions specific to the lutro global table.

 - add some const qualifiers to the newlib tables.
 - add some more stackframe checks now that there are good macros for them

Depends on PR #254 