### PR TITLE
msbuild: switch to clangcl toolchain as default, fixup player/release compile options

### DIFF
--- a/fi-warnings.h
+++ b/fi-warnings.h
@@ -38,6 +38,7 @@
 
 #pragma warning(disable:4100)	// unreferenced formal parameter
 #pragma warning(disable:4127)	// conditional expression is constant
+#pragma warning(disable:4244)		// conversion from 'intmax_t' to 'lua_Number', possible loss of data
 
 // Next section: Turn on Useful Warnings/Errors in MSC:
 

--- a/msbuild/fi-msw-buildconf.h
+++ b/msbuild/fi-msw-buildconf.h
@@ -2,4 +2,16 @@
 
 #define PLATFORM_MSW   1
 
-#pragma warning(disable : 4244)		// conversion from 'intmax_t' to 'lua_Number', possible loss of data
+#if defined(_MSC_VER) && !defined(_ITERATOR_DEBUG_LEVEL)
+#	define _ITERATOR_DEBUG_LEVEL   0
+#endif
+
+#if defined(_MSC_VER) 
+#define _CRT_NONSTDC_NO_WARNINGS   1
+#endif
+
+// putting some clangcl specific warning controls here rather than fi-warnings since they're exclusively clangcl (msbuild).
+#if defined(__clang__)
+#	pragma GCC diagnostic ignored "-Wmicrosoft-include"
+#endif
+

--- a/msbuild/lua.vcxproj
+++ b/msbuild/lua.vcxproj
@@ -53,13 +53,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>Multibyte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Multibyte</CharacterSet>
   </PropertyGroup>

--- a/msbuild/lutro.vcxproj
+++ b/msbuild/lutro.vcxproj
@@ -39,19 +39,19 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>Multibyte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tool|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>Multibyte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Player|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Multibyte</CharacterSet>
   </PropertyGroup>
@@ -84,9 +84,35 @@
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <OmitFramePointers>false</OmitFramePointers>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tool|x64'">
     <ClCompile />
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Player|x64'">
+    <ClCompile>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Player|x64'">
+    <ClCompile>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+    </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="lutro_build.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/msbuild/lutro_build.props
+++ b/msbuild/lutro_build.props
@@ -4,9 +4,11 @@
     <ClCompile>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(SolutionDir)/msbuild;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ForcedIncludeFiles>fi-msw-buildconf.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles);$(SolutionDir)/fi-warnings.h</ForcedIncludeFiles>
       <ForcedIncludeFiles>%(ForcedIncludeFiles);fi-verify-printf-msvc.h</ForcedIncludeFiles>
       <ForcedIncludeFiles>%(ForcedIncludeFiles);fi-printf-redirect.h</ForcedIncludeFiles>
     </ClCompile>
@@ -17,34 +19,39 @@
 
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <OmitFramePointers>false</OmitFramePointers>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tool|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
+      <Optimization>MaxSpeed</Optimization>
+      <OmitFramePointers>false</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Player|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
+      <OmitFramePointers>true</OmitFramePointers>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -55,13 +62,19 @@
   <!-- Release build target is used by vorbis and lua, as these don't care about Tool/Dev builds -->
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
     </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/msbuild/vorbis.vcxproj
+++ b/msbuild/vorbis.vcxproj
@@ -48,13 +48,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>Multibyte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Multibyte</CharacterSet>
   </PropertyGroup>

--- a/painter.c
+++ b/painter.c
@@ -515,6 +515,10 @@ int pntr_text_width(painter_t *p, const char *text)
    return width;
 }
 
+#if defined(__QNX__) || defined(_MSC_VER)
+// declared in libretro.c for QNX and MSC but not exposed via header file. prototype is missing.
+extern int vasprintf(char **strp, const char *fmt, va_list ap);
+#endif
 
 void pntr_printf(painter_t *p, int x, int y, const char *format, ...)
 {

--- a/tests/audio/main.lua
+++ b/tests/audio/main.lua
@@ -7,6 +7,8 @@ audio_test_name = nil
 audio_test_phase_id = 1
 last_test_phase_id = 0
 
+# disable stdout buffering so that prints are in sync with video output.
+io.stdout:setvbuf("no")
 
 local s_soundfiles = {
 	"test_s16_mono.wav",
@@ -116,7 +118,7 @@ function test_looping()
 		src:setLooping(true)
 		-- looping behavior here is that the sound will "play forever" and GC will be blocked because
 		-- the looping flag cannot be removed, since we do not retain a lua reference to the sound.
-		-- However, an all-stop of all audio sources should stop the sound. This is what we check for in veirfy.
+		-- However, an all-stop of all audio sources should stop the sound. This is what we check for in verify.
 	end
 end
 


### PR DESCRIPTION
Changes should affect only the msbuild (Visual Studio Solution) build path. This is effectively unvetted by the CI. It's not mission critical, but I do find it useful locally because Microsoft's debugger and debug information are still the best around.

 - had to make a hack fix to painter.c to work around missing prototype for vsaprintf.
 - optimizations are now (mostly) setup properly, except LTO isn't enabled yet for Player/Release builds
 
Note that retargeting the solution to use the good old v142 or v143 toolchain locally is trivial, in cases where installing clangcl is cumbersome. In general thorugh there's little reason not to install/use clangcl these days, at least for C/C99 codebases.