### PR TITLE
test: load font at toplevel main.lua and print test timer

### DIFF
--- a/image.c
+++ b/image.c
@@ -24,7 +24,6 @@ int lutro_image_preload(lua_State *L)
       {NULL, NULL}
    };
 
-   fprintf(stderr, "========= Imagre\n");
    lutro_newlib(L, img_funcs, "image");
 
    return 1;

--- a/test/graphics/print.lua
+++ b/test/graphics/print.lua
@@ -1,14 +1,8 @@
 return {
 	load = function()
-		font = lutro.graphics.newImageFont("graphics/font.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-+/")
-		lutro.graphics.setFont(font)
 	end,
 
 	draw = function()
-		-- Display test instructions.
-		text = "Tests switch every 3 seconds."
-		lutro.graphics.print(text, 30, 100)
-
 		-- Show mouse information.
 		if lutro.mouse.isDown(1, 2) then
 			local x, y = lutro.mouse.getPosition()

--- a/test/main.lua
+++ b/test/main.lua
@@ -17,6 +17,8 @@ local joystickButton = 0
 local keypressed = ""
 
 function lutro.load()
+	font = lutro.graphics.newImageFont("graphics/font.png", " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-+/")
+	lutro.graphics.setFont(font)
 	lutro.graphics.setBackgroundColor(0, 0, 0)
 
 	-- Initiate all available test states.
@@ -68,6 +70,10 @@ function lutro.draw()
 	-- Display the FPS
 	local fps = lutro.timer.getFPS()
 	lutro.graphics.print('FPS ' .. fps, 10, 350)
+
+	-- Display test instructions.
+	text = "Tests switch every 3 seconds. Counting: %.1f"
+	lutro.graphics.print(text:format(currentTime), 10,365)
 end
 
 function lutro.joystickpressed(joystick, button)


### PR DESCRIPTION
The test framework depends on the font so it should be loaded by the framework rather than being dependent on the graphics test to load it. As a result the current graphics print test doesn't make a lot of sense as it's actually a keyboard/mouse test and not a graphics print test at all. It can be improved upon separately.

Showing the timeout - it seemed like a nice courtesy and could be helpful for certain troubleshooting purposes.