### PR TITLE
Disable buffering on stdout by default.

### DIFF
--- a/lutro.c
+++ b/lutro.c
@@ -245,6 +245,10 @@ void lutro_init()
 
    luaL_openlibs(L);
 
+   // impose default behavior that ensures stdout prints in realtime and is in correct
+   // chronological sequence with stderr.
+   luaL_dostring(L, "io.stdout:setvbuf('no')");
+
 #ifdef HAVE_JIT
    luaJIT_setmode(L, -1, LUAJIT_MODE_WRAPCFUNC|LUAJIT_MODE_ON);
 #endif


### PR DESCRIPTION
This change imposes a default behavior that ensures stdout prints in realtime and is in correct chronological sequence with stderr. It is the generally expected behavior for any multimedia or gaming application. If a specialized script (for unit testing?) intends only to output large sets of results to stdout, it can optionally re-enabe this buffering within that script to gain a tiny amount of execution speed.

I had added code to tests/audio to turn this on manually, and was about to do the same thing to the other test, when I realized it is better done by default for all game apps. There is no tangible benefit to buffered stdout for games, and tons of drawbacks.