### PR TITLE
getUserDirectory: return libretro Save Directory instead of $USER env

### DIFF
--- a/filesystem.h
+++ b/filesystem.h
@@ -21,8 +21,8 @@ int fs_setIdentity(lua_State *L);
 int fs_isFile(lua_State *L);
 int fs_isDirectory(lua_State *L);
 int fs_createDirectory(lua_State *L);
-int fs_getUserDirectory(lua_State *L);
 int fs_getAppdataDirectory(lua_State *L);
+int fs_getWorkingDirectory(lua_State *L);
 int fs_getDirectoryItems(lua_State *L);
 
 #endif // FILESYSTEM_H

--- a/test/unit/modules/filesystem.lua
+++ b/test/unit/modules/filesystem.lua
@@ -20,10 +20,15 @@ function lutro.filesystem.getAppdataDirectoryTest()
 end
 
 function lutro.filesystem.getUserDirectoryTest()
-    local homeDir = lutro.filesystem.getUserDirectory()
-    -- @todo Find out how to make os.getenv('HOME') work on Windows?
-    local luaHomeDir = os.getenv("HOME")
-    unit.assertEquals(homeDir, luaHomeDir)
+    -- UserDirectory should always have a trailing slash. This is easy to verify.
+    -- Other aspects of UserDirectory are platform specific and non-trivial to calculate and there
+    -- isn't much value to trying to replicate it here.
+    local userDir = lutro.filesystem.getUserDirectory()
+    local userDirFixed = getUserDir
+    if userDirFixed:sub(-1) ~= '/' then
+        userDirFixed = userDirFixed .. '/'
+    end
+    unit.assertEquals(userDir, userDirFixed)
 end
 
 function lutro.filesystem.getDirectoryItemsTest()


### PR DESCRIPTION
 - Fixes a mem corruption bug: adding a trailing slash was corrupting the env table of the process
 - converted implementation to use `lual_dostring` thus performing non-trivial string operations within the safe GC'd confines of Lua

`getUserDirectory` returns nil if the libretro frontend doesn't support it. This is done rather than using a substitution because there is no suitable substitution that is guaranteed to be writable. It's better to fail on returning a valid path than to fail in unexpected ways later on when trying to write data to the directory. The love/lutro game app will need to check for hand handle such cases appropriately if it wants to be well-behaved running under libretro.

### random thought
It occurs to me that it could be swell if there was an IDE and/or C preprocessor that allowed embedding lua into C code. Something similar perhaps to how one can embed PHP code inside HTML, as an example.