### PR TITLE
getWorkingDirectory: implemented to return "./"

### DIFF
--- a/filesystem.c
+++ b/filesystem.c
@@ -1,10 +1,19 @@
 #include "filesystem.h"
 #include "lutro.h"
+#include "lutro_assert.h"
+
 #include <compat/strl.h>
 #include <file/file_path.h>
 #include <streams/file_stream.h>
 #include <vfs/vfs_implementation.h>
 #include <string/stdstring.h>
+
+// for getcwd...
+#if defined(_WIN32)
+#  include <direct.h>
+#else
+#  include <unistd.h>
+#endif
 
 #if WANT_PHYSFS
 #include "physfs.h"
@@ -36,6 +45,7 @@ int lutro_filesystem_preload(lua_State *L)
       { "load",        fs_load },
       { "setIdentity", fs_setIdentity },
       { "getAppdataDirectory", fs_getAppdataDirectory },
+      { "getWorkingDirectory", fs_getWorkingDirectory },
       { "isDirectory", fs_isDirectory },
       { "isFile",      fs_isFile },
       { "createDirectory", fs_createDirectory },
@@ -289,6 +299,24 @@ int fs_getAppdataDirectory(lua_State *L)
    else {
       lua_pushstring(L, "");
    }
+   return 1;
+}
+
+
+/**
+ * lutro.filesystem.getWorkingDirectory
+ *
+ * Retrieves the process current working directory (cwd or pwd). Lutro always returns the 
+ * relative directory prefix "./" which is generally interpreted by filesystem APIs as the
+ * cwd when used as the prefix to a function. LOVE returns the CWD as an absolute path.
+ * Note that the concept of cwd is inherently non-portable and leads to unexpected or surprising
+ * behavior for users, and should only be used for local development or debug purposes.
+ *
+ * @see https://love2d.org/wiki/love.filesystem.getWorkingDirectory
+ */
+int fs_getWorkingDirectory(lua_State *L)
+{
+   lua_pushstring(L, "./");
    return 1;
 }
 

--- a/test/unit/modules/filesystem.lua
+++ b/test/unit/modules/filesystem.lua
@@ -19,6 +19,15 @@ function lutro.filesystem.getAppdataDirectoryTest()
     unit.assertIsString(appdataDir)
 end
 
+function lutro.filesystem.getWorkingDirectoryTest()
+    local getWorkingDir = lutro.filesystem.getWorkingDirectory()
+    local getWorkingDirFixed = getWorkingDir
+    if getWorkingDirFixed:sub(-1) ~= '/' then
+        getWorkingDirFixed = getWorkingDirFixed .. '/'
+    end
+    unit.assertEquals(getWorkingDir, getWorkingDirFixed)
+end
+
 function lutro.filesystem.getUserDirectoryTest()
     -- UserDirectory should always have a trailing slash. This is easy to verify.
     -- Other aspects of UserDirectory are platform specific and non-trivial to calculate and there
@@ -58,6 +67,7 @@ end
 return {
     lutro.filesystem.setRequirePathTest,
     lutro.filesystem.getRequirePathTest,
+    lutro.filesystem.getWorkingDirectoryTest,
     lutro.filesystem.getUserDirectoryTest,
     lutro.filesystem.getAppdataDirectoryTest,
     lutro.filesystem.getDirectoryItemsTest,


### PR DESCRIPTION
It's enough to allow most things that might want to use it to work. The function should only be used for local development or debugging purposes anyway, as the concept of CWD is not portable and is not friendly to end users running program via high-level shells (eg. Windows Explorer or Finder or such).

Difference from LOVE:  LOVE returns the CWD as an absolute path. Lutro returns a relative path.

I split it out from PR #260 since the latest implementation of `getUserDirectory` will no longer use `getCurrentDirectory` as a fallback. I felt it was still worthwhile to retain the work of implementing `getCurrentDirectory()` even if it's not directly supported by libretro API, and not recommended to use it anywhere outside of local/development contexts. I think it is still nice to have these sort of dev-friendly APIs available for use, and assume devs will use them effectively and responsibly.