### PR TITLE
lutro: fix a whoooole bunch of prototype warnings.

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -274,7 +274,7 @@ void lutro_audio_init(lua_State* L)
    lua_setglobal(L, "refs_audio_playing");
 }
 
-void lutro_audio_deinit()
+void lutro_audio_deinit(void)
 {
    if (!sources_playing) return;
 

--- a/audio.h
+++ b/audio.h
@@ -36,7 +36,7 @@ typedef struct
 } audio_Source;
 
 void lutro_audio_init(lua_State* L);
-void lutro_audio_deinit();
+void lutro_audio_deinit(void);
 void lutro_audio_stop_all(lua_State* L);
 int lutro_audio_preload(lua_State *L);
 void lutro_mixer_render(int16_t* buffer);

--- a/event.c
+++ b/event.c
@@ -18,7 +18,7 @@ int lutro_event_preload(lua_State *L)
    return 1;
 }
 
-void lutro_event_init()
+void lutro_event_init(void)
 {
 }
 

--- a/filesystem.c
+++ b/filesystem.c
@@ -108,14 +108,14 @@ int lutro_filesystem_preload(lua_State *L)
    return 1;
 }
 
-void lutro_filesystem_init()
+void lutro_filesystem_init(void)
 {
    #if WANT_PHYSFS
    PHYSFS_init(NULL);
    #endif
 }
 
-void lutro_filesystem_deinit()
+void lutro_filesystem_deinit(void)
 {
    #if WANT_PHYSFS
    PHYSFS_deinit();

--- a/filesystem.h
+++ b/filesystem.h
@@ -7,8 +7,8 @@
 #include <stdbool.h>
 #include "runtime.h"
 
-void lutro_filesystem_init();
-void lutro_filesystem_deinit();
+void lutro_filesystem_init(void);
+void lutro_filesystem_deinit(void);
 int lutro_filesystem_preload(lua_State *L);
 
 int fs_read(lua_State *L);

--- a/image.c
+++ b/image.c
@@ -29,7 +29,7 @@ int lutro_image_preload(lua_State *L)
    return 1;
 }
 
-void lutro_image_init()
+void lutro_image_init(void)
 {
 }
 

--- a/image.h
+++ b/image.h
@@ -29,7 +29,7 @@
 #define BLUE_MASK 0x000000FF
 #endif
 
-void lutro_image_init();
+void lutro_image_init(void);
 int lutro_image_preload(lua_State *L);
 
 void *image_data_create_from_path(lua_State *L, const char *path);

--- a/lutro.c
+++ b/lutro.c
@@ -236,7 +236,7 @@ void lutro_newlib_x(lua_State* L, luaL_Reg const* funcs, char const* fieldname, 
    lua_pop(L, 1);
 }
 
-void lutro_init()
+void lutro_init(void)
 {
    L = luaL_newstate();
 
@@ -316,7 +316,7 @@ void lutro_init()
    player_checked_stack_end(L, 0);
 }
 
-void lutro_deinit()
+void lutro_deinit(void)
 {
 #ifdef HAVE_INOTIFY
    if (settings.live_enable)
@@ -661,7 +661,7 @@ void lutro_run(double delta)
    lua_gc(L, LUA_GCSTEP, 0);
 }
 
-void lutro_reset()
+void lutro_reset(void)
 {
    player_checked_stack_begin(L);
    luax_reqglobal(L, "lutro");
@@ -680,7 +680,7 @@ void lutro_reset()
    lua_gc(L, LUA_GCSTEP, 0);
 }
 
-size_t lutro_serialize_size()
+size_t lutro_serialize_size(void)
 {
    size_t size = 0;
 
@@ -779,7 +779,7 @@ void lutro_cheat_set(unsigned index, bool enabled, const char *code)
    lua_gc(L, LUA_GCSTEP, 0);
 }
 
-void lutro_cheat_reset()
+void lutro_cheat_reset(void)
 {
    player_checked_stack_begin(L);
    luax_reqglobal(L, "lutro");
@@ -878,7 +878,7 @@ void *lutro_realloc_internal(void *ptr, size_t size, const char* debug, int line
     return a;
 }
 
-void lutro_print_allocation() {
+void lutro_print_allocation(void) {
 #if TRACE_ALLOCATION
     fprintf(stderr,"TRACE ALLOC:total pending allocations:%d\n", allocation_count);
 #endif

--- a/lutro.h
+++ b/lutro.h
@@ -37,16 +37,16 @@ typedef struct lutro_settings_t {
 extern lutro_settings_t settings;
 extern struct retro_perf_callback perf_cb;
 
-void lutro_init();
-void lutro_deinit();
+void lutro_init(void);
+void lutro_deinit(void);
 
 int lutro_load(const char *path);
 void lutro_run(double delta);
-void lutro_reset();
-size_t lutro_serialize_size();
+void lutro_reset(void);
+size_t lutro_serialize_size(void);
 bool lutro_serialize(void *data_, size_t size);
 bool lutro_unserialize(const void *data_, size_t size);
-void lutro_cheat_reset();
+void lutro_cheat_reset(void);
 void lutro_cheat_set(unsigned index, bool enabled, const char *code);
 
 void lutro_shutdown_game(void);
@@ -68,7 +68,7 @@ void *lutro_malloc_internal(size_t size, const char* debug, int line);
 void *lutro_calloc_internal(size_t nmemb, size_t size, const char* debug, int line);
 void *lutro_realloc_internal(void *ptr, size_t size, const char* debug, int line);
 void lutro_free_internal(void *ptr, const char* debug, int line);
-void lutro_print_allocation();
+void lutro_print_allocation(void);
 #define lutro_malloc(size) lutro_malloc_internal(size, __FILE__, __LINE__)
 #define lutro_calloc(nmemb, size) lutro_calloc_internal(nmemb, size, __FILE__, __LINE__)
 #define lutro_realloc(ptr, size) lutro_realloc_internal(ptr, size, __FILE__, __LINE__)

--- a/lutro_math.c
+++ b/lutro_math.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <time.h>
 
-void lutro_math_init()
+void lutro_math_init(void)
 {
     time_t t;
     srand((unsigned) time(&t));

--- a/lutro_math.h
+++ b/lutro_math.h
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include "runtime.h"
 
-void lutro_math_init();
+void lutro_math_init(void);
 int lutro_math_preload(lua_State *L);
 int lutro_math_random(lua_State *L);
 int lutro_math_setRandomSeed(lua_State *L);

--- a/lutro_window.c
+++ b/lutro_window.c
@@ -33,7 +33,7 @@ int lutro_window_preload(lua_State *L)
    return 1;
 }
 
-void lutro_window_init()
+void lutro_window_init(void)
 {
 }
 

--- a/lutro_window.h
+++ b/lutro_window.h
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include "runtime.h"
 
-void lutro_window_init();
+void lutro_window_init(void);
 int lutro_window_preload(lua_State *L);
 
 int win_close(lua_State *L);

--- a/mouse.c
+++ b/mouse.c
@@ -23,7 +23,7 @@ int lutro_mouse_preload(lua_State *L)
    return 1;
 }
 
-void lutro_mouse_init()
+void lutro_mouse_init(void)
 {
 }
 

--- a/mouse.h
+++ b/mouse.h
@@ -6,7 +6,7 @@
 #include "runtime.h"
 
 int lutro_mouse_preload(lua_State *L);
-void lutro_mouse_init();
+void lutro_mouse_init(void);
 void lutro_mouseevent(lua_State* L);
 int mouse_isDown(lua_State *L);
 int mouse_getX(lua_State *L);

--- a/sound.c
+++ b/sound.c
@@ -19,7 +19,7 @@ int lutro_sound_preload(lua_State *L)
    return 1;
 }
 
-void lutro_sound_init()
+void lutro_sound_init(void)
 {
 }
 

--- a/sound.h
+++ b/sound.h
@@ -20,7 +20,7 @@ typedef struct
    mixer_presaturate_t* data;
 } snd_SoundData;
 
-void lutro_sound_init();
+void lutro_sound_init(void);
 int lutro_sound_preload(lua_State *L);
 
 int snd_newSoundData(lua_State *L);

--- a/system.c
+++ b/system.c
@@ -27,7 +27,7 @@ int lutro_system_preload(lua_State *L)
    return 1;
 }
 
-void lutro_system_init()
+void lutro_system_init(void)
 {
 }
 

--- a/system.h
+++ b/system.h
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include "runtime.h"
 
-void lutro_system_init();
+void lutro_system_init(void);
 int lutro_system_preload(lua_State *L);
 
 int sys_getOS(lua_State *L);

--- a/timer.c
+++ b/timer.c
@@ -18,7 +18,7 @@ int lutro_timer_preload(lua_State *L)
    return 1;
 }
 
-void lutro_timer_init()
+void lutro_timer_init(void)
 {
 }
 

--- a/timer.h
+++ b/timer.h
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include "runtime.h"
 
-void lutro_timer_init();
+void lutro_timer_init(void);
 int lutro_timer_preload(lua_State *L);
 
 int timer_getTime(lua_State *L);


### PR DESCRIPTION
An interesting trivia of C99/C11 is that it isn't supposed to allow `()` for void functions. This is due to a classic rule of C language where `()` was actually a type of varadic, and matches any number of arguments. Thus, the use of either `(void)` or `(...)` is recommended for C programs to clearly differentiate them from the ambiguous `()` definition. (this doesn't apply to C++ code)