### PR TITLE
Add lutro.featureflags table, for use in determining lutro build capabilities

### DIFF
--- a/lutro.c
+++ b/lutro.c
@@ -204,9 +204,41 @@ static void init_lutro_global_table(lua_State *L)
    lua_pop(L, 1);
 }
 
+// reveals which configuration options were used to compile lutro.
+static void init_config(lua_State *L)
+{   
+   player_checked_stack_begin(L);
+
+   luax_reqglobal(L, "lutro");
+   lua_newtable(L);
+
+   char buf[128];
+
+   #define STR(a) #a
+   #define CAPABILITY(cap)                           \
+      snprintf(buf, sizeof(buf), "%s", #cap);        \
+      lua_pushboolean(L, (buf[0] && strtold(buf, NULL) != 0)); \
+      lua_setfield(L, -2, #cap)
+
+   CAPABILITY(HAVE_COMPOSITION);
+   CAPABILITY(HAVE_TRANSFORM);
+   CAPABILITY(HAVE_INOTIFY);
+   CAPABILITY(HAVE_JIT);
+   CAPABILITY(HAVE_LUASOCKET);
+
+   #undef STR
+   #undef CAPABILITY
+
+   lua_setfield(L, -2, "featureflags");
+   lua_pop(L, 1);
+
+   (void)player_checked_stack_end(L,0);
+}
 
 static int lutro_core_preload(lua_State *L)
 {
+   init_config(L);
+
    return 1;
 }
 
@@ -229,11 +261,13 @@ static void init_settings(lua_State *L)
 
 void lutro_newlib_x(lua_State* L, luaL_Reg const* funcs, char const* fieldname, int numfuncs)
 {
+   player_checked_stack_begin(L);
    luax_reqglobal(L, "lutro");
    lua_createtable(L, 0, numfuncs);
    luaL_setfuncs(L, funcs, 0);
    lua_setfield(L, -2, fieldname);
    lua_pop(L, 1);
+   player_checked_stack_end(L,0);
 }
 
 void lutro_init()

--- a/test/main.lua
+++ b/test/main.lua
@@ -1,5 +1,6 @@
 -- Lutro Tester
 local availableStates = {
+	"config/print",
 	"graphics/print",
 	"unit/tests",
 	"joystick/isDown",

--- a/test/unit/modules/filesystem.lua
+++ b/test/unit/modules/filesystem.lua
@@ -24,7 +24,7 @@ function lutro.filesystem.getUserDirectoryTest()
     -- Other aspects of UserDirectory are platform specific and non-trivial to calculate and there
     -- isn't much value to trying to replicate it here.
     local userDir = lutro.filesystem.getUserDirectory()
-    local userDirFixed = getUserDir
+    local userDirFixed = userDir
     if userDirFixed:sub(-1) ~= '/' then
         userDirFixed = userDirFixed .. '/'
     end

--- a/test/unit/tests.lua
+++ b/test/unit/tests.lua
@@ -7,6 +7,7 @@ unit = require 'luaunit'
 -- Runs all tests.
 function runTests()
 	local moduleTests = {
+		require 'modules/featureflags',
 		require 'modules/filesystem',
 		require 'modules/graphics',
 		require 'modules/keyboard',


### PR DESCRIPTION
This is primarily intended for use in internal dev and unit test development. A practical application is that it can be used (soon) to detect whether the lutro build supports the transform rendering feature, and then alter lua graphics test behavior accordingly.

This change was inspired by work done in PR #215 which adds Transform and Scaling features.

I've selected the name `lutro.featureflags` instead of `lutro.config` used in PR #215 to improve clarity and avoid ambiguity with various other types of configurations (namely ones coming from data-driven or runtime sources such as ini files, for which the term 'config' is probably more readily associated). 

### test output

Running the unit tests produces this output:
```
$ ./runtest.sh test/unit/main.lua
lutro.featureflags.HAVE_COMPOSITION = false
lutro.featureflags.HAVE_JIT = false
lutro.featureflags.HAVE_INOTIFY = false
lutro.featureflags.HAVE_TRANSFORM = false
lutro.featureflags.HAVE_LUASOCKET = false
Lutro unit test run complete
```