### PR TITLE
featureflags: fix a bug which caused all flags to report as 'false'

### DIFF
--- a/test/main.lua
+++ b/test/main.lua
@@ -1,6 +1,5 @@
 -- Lutro Tester
 local availableStates = {
-	"config/print",
 	"graphics/print",
 	"unit/tests",
 	"joystick/isDown",

--- a/test/unit/modules/featureflags.lua
+++ b/test/unit/modules/featureflags.lua
@@ -1,0 +1,37 @@
+
+local function printBuildFlags()
+    -- Step 1: duplicate the table
+    -- Step 2: Sort the array alphabetically
+    -- Step 3: Iterate over the sorted array
+
+    local copy = {}
+    for k in pairs(lutro.featureflags) do
+        table.insert(copy, k)
+    end
+
+    table.sort(copy, function(a, b)
+        return a:lower() < b:lower()
+    end)
+
+    -- named prefixed with _ are for internal lutro use.
+    for _, key in ipairs(copy) do
+        if not key:find("^_") then
+            print( ("lutro.featureflags.%s = %s"):format(key, tostring(lutro.featureflags[key])) )
+        end
+    end
+end
+
+local function verify_as_truefalse()
+    unit.assertEquals(lutro.featureflags._VERIFY_AS_TRUE,  true)
+    unit.assertEquals(lutro.featureflags._VERIFY_AS_FALSE, false)
+end
+
+local function verify_as_undefined()
+    unit.assertEquals(lutro.featureflags._VERIFY_AS_UNDEFINED, false)
+end
+
+return {
+    printBuildFlags,
+    verify_as_truefalse,
+    verify_as_undefined,
+}


### PR DESCRIPTION
Adds the featureflag unit test, which was missing from my previous PR (forgot to add).

Also clarifies the use of "feature flags" as the term for this new table, both in function name and comments.

This bug slipped in as a result (as usual) of some late-stage cleanup and refactor that I did just before commit.  As a result, I went ahead and implemented a unit test of sorts that I had kind of thought about implementing earlier but, due to time constraints, I opted to skip past.

An _score naming convention is used to differentiate the internal values for unit testing from the regular values.

