### PR TITLE
make: fix PhysFS defines to match expected assignment of [0,1]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ endif
 compiler_brand := $(shell $(CC) --version | grep -o -m1 clang || echo gcc)
 cc_version := $(shell $(CC) -dumpversion)
 
-WARN_FLAGS = 
+WARN_FLAGS ?= 
 
 # Clang compiler can pedantically generate compiler errors for printf formatting.
 # Printf formatting errors often result in undefined program behavior (crashes).

--- a/Makefile.common
+++ b/Makefile.common
@@ -158,7 +158,7 @@ endif
 
 # PhysFS
 ifeq ($(WANT_PHYSFS), 1)
-    DEFINES += -DWANT_PHYSFS
+    DEFINES += -DWANT_PHYSFS=1
     DEPS_DIR_PHYSFS := $(CORE_DIR)/deps/physfs
     CFLAGS += -I$(DEPS_DIR_PHYSFS)
     SOURCES_C_PHYSFS = $(DEPS_DIR_PHYSFS)/physfs.c \
@@ -183,12 +183,12 @@ ifeq ($(WANT_PHYSFS), 1)
         $(DEPS_DIR_PHYSFS)/physfs_platform_windows.c
     SOURCES_C += $(SOURCES_C_PHYSFS)
     ifeq ($(WANT_ZLIB),1)
-        DEFINES += -DPHYSFS_SUPPORTS_ZIP
+        DEFINES += -DPHYSFS_SUPPORTS_ZIP=1
     endif
 
     ifeq ($(platform),unix)
-        DEFINES += -DPHYSFS_PLATFORM_UNIX
-        DEFINES += -DPHYSFS_PLATFORM_LINUX
+        DEFINES += -DPHYSFS_PLATFORM_UNIX=1
+        DEFINES += -DPHYSFS_PLATFORM_LINUX=1
     endif
 endif
 


### PR DESCRIPTION
When a codebase uses `#if HAVE_FOOBAR` it is necessary to use `HAVE_FOOBAR=1` to ensure the compiler actually enables the codeblock in the expected way. When the code uses `#ifdef HAVE_FOOBAR` then a define without any assignment is sufficient to enable the feature.

The `#if` is recommended over the `#ifdef` form for reasons of explicitness, along with a few other minor benefits related to inheriting or overriding the set value later on in the build system or at the source code level. PhysFs uses/expects this form, but lutro generally does not (yet).