### PR TITLE
tests: fixed init/dt regressions and add os.exit() if UNATTENDED=1 

### DIFF
--- a/test/window/close.lua
+++ b/test/window/close.lua
@@ -1,6 +1,36 @@
+local m_is_unattended = false
+
 return {
+	load = function()
+		-- When deciding to terminate the process, check for "UNATTENDED" env var. This is preferred over
+		-- "CI" as the name is more explicit. "CI" is short and likely to have other meanings in casual
+		-- user/developer environments and should be avoided when making potentially surprising actions
+		-- like sudden process termination.
+		local env_ci = os.getenv("UNATTENDED")
+		if env_ci then
+			print ("env: UNATTENDED=" .. env_ci)
+			env_ci = env_ci:lower()
+			-- consider any value other than something specifically "false" as a truthy value.
+			if env_ci ~= "false" and env_ci ~= "0" and env_ci ~= "no" then
+				m_is_unattended = true
+			end
+		end
+	end,
+
 	draw = function()
-		print "All Tests Complete. Closing Window..."
+		-- test that window.close() operates normally, but also terminate the process via lua to
+		-- force stop the test even if the libretro frontend is designed or configured to be persistent.
+		-- This allows using the tests via some automatic PR sweeps.
+
+		print ("All Tests Complete. Closing libretro frontend window...")
 		lutro.window.close()
+
+		if m_is_unattended then
+			print (" > Exiting process due to env UNATTENDED=" .. os.getenv("UNATTENDED"))
+			os.exit()
+		else
+			print ("Note: Libretro frontend may continue running depending on mode/settings.")
+			print (" > Set UNATTENDED=1 in the process environment to exit the libretro frontend immediately.")
+		end
 	end
 }

--- a/test/window/close.lua
+++ b/test/window/close.lua
@@ -1,5 +1,6 @@
 return {
 	draw = function()
+		print "All Tests Complete. Closing Window..."
 		lutro.window.close()
 	end
 }


### PR DESCRIPTION
 - load() function was not being called due to some merge error conflict that added an extra "end" in the wrong place
 - the `dt` value was not passed into `update(dt)` due to a difference in how `xpcall()` works between lua 5.1 and 5.2
 - switched syntax from `state.['member']` to `state.member` for readability
 - Fixes inconsistent background color by setting the background color ever frame instead of just once on Load()

### calling os.exit() if UNATTENDED=1 (env)

This should be some handy boilerplate to facilitate running tests as part of PR smoke checks. It's also useful for my local bash shell driven development testing too, but I'm hesitant to make it the default behavior, since I can imagine other workflows that might use a persistent instance of retroarch to relaunch the test repeatedly after lua modifications.

Getting pretty close to the point where the unit tests - or some significant subset of them - should be runnable via the CI to improve PR test coverage. _(still some blockers such as having a libretro frontend that can run in a way that is friendly to the restrictions imposed by github runners, eg. no GPU)_