### PR TITLE
Make `getDirectoryItems` be 1-indexed

### DIFF
--- a/filesystem.c
+++ b/filesystem.c
@@ -391,7 +391,7 @@ int fs_getDirectoryItems(lua_State *L)
 
    // Prepare the output table.
    lua_newtable(L);
-   int index = 0;
+   int index = 1;
 
    // Iterate through each directory entry, ignoring the current and previous directories.
    while (retro_vfs_readdir_impl(dir)) {


### PR DESCRIPTION
Forgive me if I'm wrong, I'm new to Lua, but shouldn't the table be 1-indexed? As is right now, a naive iteration through the table or using functions like `table.concat` will ignore the first item in the directory.

I do realize that this would be a breaking change, so an alternative would also be to add the fact that it's 0-indexed as a warning to the docs.